### PR TITLE
Remove duplication in flags, undefined in ROOTAnalGas class and other…

### DIFF
--- a/include/ActarSimROOTAnalGas.hh
+++ b/include/ActarSimROOTAnalGas.hh
@@ -1,14 +1,14 @@
 /////////////////////////////////////////////////////////////////
-//*-- AUTHOR : Hector Alvarez Pol 
+//*-- AUTHOR : Hector Alvarez Pol
 //*-- Date: 04/2008
-//*-- Last Update: 23/12/14 by Hector Alvarez Pol
+//*-- Last Update: 14/06/16 by Hector Alvarez Pol
 // --------------------------------------------------------------
 // Description:
-//   The ACTAR gas detector part of the ROOT Analysis   
+//   The ACTAR gas detector part of the ROOT Analysis
 //
 // --------------------------------------------------------------
 // Comments:
-// 
+//
 // --------------------------------------------------------------
 /////////////////////////////////////////////////////////////////
 
@@ -57,7 +57,7 @@ private:
   TFile* simFile;               //Local pointer to simFile
   TTree* eventTree; //Tree
   TTree* tracksTree; //Tree
-  
+
   TBranch* dataBranch; //Local branch
   TBranch* simpleTrackBranch; //Local branch
   TBranch* trackBranch; //Local branch
@@ -72,15 +72,15 @@ private:
   TH2D *htrackInPads;
   TH2D *htrack1InPads;
   TH2D *htrack2InPads;
- 
+
   TH1D *hEdepInGas;// Energy deposit in Gas over the distance
- 
+
   ///// The accumulated energy loss and track length of each step, dypang 080225
   TProfile *hbeamEnergyAtRange;
   ///// end of dypang part 080225
-  
+
   TH2D *htrackFromBeam;
-  
+
   TH3D *htrack;
 
   //Control of minimum simpleTrack stride length
@@ -92,19 +92,12 @@ private:
   G4double primTheta;
   G4double primPhi;
 
-  //Flags for control
-  G4String  storeTracksFlag;
-  G4String  storeTrackHistosFlag;
-  G4String  storeEventsFlag;
-  G4String  storeSimpleTracksFlag;
-
   G4int theRunID; //To keep some numbers on the Tree
   G4int theEventID; //To keep some numbers on the Tree
 
 public:
 
   ActarSimROOTAnalGas();
-  ActarSimROOTAnalGas(G4String, G4String, G4String, G4String);
   ~ActarSimROOTAnalGas();
 
   void init();
@@ -137,21 +130,9 @@ public:
   void SetTrackBranch(TBranch* aBranch) {trackBranch= aBranch;}
   TBranch* GetSimpleTrackBranch(){return simpleTrackBranch;}
   void SetSimpleTrackBranch(TBranch* aBranch) {simpleTrackBranch= aBranch;}
-  
-  TClonesArray* getSimpleTrackCA(void){return simpleTrackCA;} 
-  void SetSimpleTrackCA(TClonesArray* CA) {simpleTrackCA = CA;}
 
-  //Messenger actions
-  void SetStoreTracksFlag(G4String val) {storeTracksFlag = val;};
-  void SetStoreTrackHistosFlag(G4String val) {storeTrackHistosFlag = val;};
-  void SetStoreEventsFlag(G4String val) {storeEventsFlag = val;};
-  void SetStoreSimpleTracksFlag(G4String val) {storeSimpleTracksFlag=val;};
-  void SetStoreFlags(G4String TF,G4String THF,G4String EF,G4String STF){
-	storeTracksFlag=TF;
-	storeTrackHistosFlag=THF;
-	storeEventsFlag=EF;
-	storeSimpleTracksFlag=STF;
-	}
+  TClonesArray* getSimpleTrackCA(void){return simpleTrackCA;}
+  void SetSimpleTrackCA(TClonesArray* CA) {simpleTrackCA = CA;}
 
   // G4VUserPrimaryGeneratorAction
   void GeneratePrimaries(const G4Event*);
@@ -169,4 +150,3 @@ public:
 
 };
 #endif
-

--- a/include/ActarSimROOTAnalysis.hh
+++ b/include/ActarSimROOTAnalysis.hh
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez-Pol
 //*-- Date: 03/2005
-//*-- Last Update: 07/01/15 by hapol
+//*-- Last Update: 14/06/16 by hapol
 // --------------------------------------------------------------
 // Description:
 //   ROOT-based analysis functionality
@@ -173,6 +173,13 @@ public:
   void SetStoreSimpleTracksFlag(G4String val) {storeSimpleTracksFlag=val;};
   void SetStoreHistogramsFlag(G4String val) {storeHistogramsFlag=val;};
   void SetBeamInteractionFlag(G4String val){beamInteractionFlag=val;}
+
+  G4String GetStoreTracksFlag() {return storeTracksFlag;}
+  G4String GetStoreTrackHistosFlag() {return storeTrackHistosFlag;}
+  G4String GetStoreEventsFlag() {return storeEventsFlag;}
+  G4String GetStoreSimpleTracksFlag() {return storeSimpleTracksFlag;}
+  G4String GetStoreHistogramsFlag() {return storeHistogramsFlag;}
+  G4String GetBeamInteractionFlag(){return beamInteractionFlag;}
 
   G4int GetGasAnalStatus(){return gasAnalIncludedFlag;}
   G4int GetSilAnalStatus(){return silAnalIncludedFlag;}

--- a/src/ActarSimROOTAnalGas.cc
+++ b/src/ActarSimROOTAnalGas.cc
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez Pol
 //*-- Date: 05/2005
-//*-- Last Update: 23/12/14 by Hector Alvarez Pol
+//*-- Last Update: 14/06/16 by Hector Alvarez Pol
 // --------------------------------------------------------------
 // Description:
 //   The gas detector part of the ROOT Analysis
@@ -51,21 +51,9 @@
 //for calculating the optical photon wavelenght for a given enegy
 //static const G4double LambdaE = twopi * 1.973269602e-16 * m * GeV;
 
-ActarSimROOTAnalGas::ActarSimROOTAnalGas():
-  storeTracksFlag("off"), storeTrackHistosFlag("off"),
-  storeEventsFlag("off"), storeSimpleTracksFlag("on") {
+ActarSimROOTAnalGas::ActarSimROOTAnalGas(){
   //
   // Default constructor... Simply inits
-  //
-  init();
-}
-
-ActarSimROOTAnalGas::ActarSimROOTAnalGas(G4String sTFlag, G4String sTHFlag,
-                                         G4String sEFlag, G4String sSTFlag ):
-  storeTracksFlag(sTFlag), storeTrackHistosFlag(sTHFlag),
-  storeEventsFlag(sEFlag), storeSimpleTracksFlag(sSTFlag) {
-  //
-  // Constructor
   //
   init();
 }
@@ -76,11 +64,6 @@ void ActarSimROOTAnalGas::init(){
   //
   G4cout << "##################################################################" << G4endl
 	       << "###########    ActarSimROOTAnalGas::init()    ####################" << G4endl;
-  G4cout << "########  Flags: storeTracksFlag=" << storeTracksFlag
-	       << ", storeTrackHistosFlag=" << storeTrackHistosFlag << "  ######" << G4endl
-	       << "######## storeEventsFlag=" << storeEventsFlag
-	       << ", storeSimpleTracksFlag=" << storeSimpleTracksFlag << "  ######" << G4endl;
-  G4cout << "################################################################## " << G4endl;
 
   //The simulation file
   simFile = ((ActarSimROOTAnalysis*) gActarSimROOTAnalysis)->GetSimFile();
@@ -203,7 +186,8 @@ void ActarSimROOTAnalGas::BeginOfRunAction(const G4Run *aRun) {
     hStepSumLengthOnGas2 = new TH1D("hStepSumLengthOnGas2","Step Sum Length On Gas for second primary", 1000, 0.0, 1000.0);// in [cm]
     if (hStepSumLengthOnGas2) hStepSumLengthOnGas2->SetXTitle("[mm]");
   }
-  if(storeTrackHistosFlag == "on") {
+
+  if(((ActarSimROOTAnalysis*) gActarSimROOTAnalysis)->GetStoreTrackHistosFlag()== "on") {
     htrackInPads =
       (TH2D *)gROOT->FindObject("htrackInPads");
     if(htrackInPads) htrackInPads->Reset();
@@ -318,7 +302,7 @@ void ActarSimROOTAnalGas::EndOfRunAction(const G4Run *aRun) {
 
   G4int nbofEvents = aRun->GetNumberOfEvent();
 
-  if(storeTrackHistosFlag == "on") {
+  if(((ActarSimROOTAnalysis*) gActarSimROOTAnalysis)->GetStoreTrackHistosFlag() == "on") {
     //G4double binWidth = hEdepInGas->GetBinWidth();
     hEdepInGas->Scale(1./nbofEvents);
     //G4cout << "Number of events: "<< nbofEvents << G4endl;
@@ -345,7 +329,7 @@ void ActarSimROOTAnalGas::EndOfEventAction(const G4Event *anEvent) {
   Double_t aTLInGas1 =0;// (TLGas1 / mm); // in [mm]
   Double_t aTLInGas2 =0;// (TLGas2 / mm); // in [mm]
 
-  if(storeSimpleTracksFlag=="on"){  // added flag dypang 080301
+  if(((ActarSimROOTAnalysis*) gActarSimROOTAnalysis)->GetStoreSimpleTracksFlag()=="on"){  // added flag dypang 080301
     //moving here the recollection of the steps info into strides
     //which was previously made in the UserSteppingAction() function
     //Now we will use the GeantHits to recover the steps from the gas
@@ -480,17 +464,16 @@ void ActarSimROOTAnalGas::EndOfEventAction(const G4Event *anEvent) {
       }
     }
   }
-  //David Perez Loureiro ----------------------------//
-  if(storeEventsFlag=="on"){  // added flag dypang 080301
+ if(((ActarSimROOTAnalysis*) gActarSimROOTAnalysis)->GetStoreEventsFlag()=="on"){
     theData->SetEnergyOnGasPrim1(aEnergyInGas1);
     theData->SetEnergyOnGasPrim2(aEnergyInGas2);
     theData->SetStepSumLengthOnGasPrim1(aTLInGas1);
-    //G4cout << "SetStepSumLengthOnGasPrim1=" << aTLInGas1 << ", dypang, 080820" << G4endl;
     theData->SetStepSumLengthOnGasPrim2(aTLInGas2);
     theData->SetEventID(anEvent->GetEventID());
     theData->SetRunID(GetTheRunID());
   }
-  if(storeTrackHistosFlag=="on"){  // added flag dypang 080301
+
+  if(((ActarSimROOTAnalysis*) gActarSimROOTAnalysis)->GetStoreTrackHistosFlag()=="on"){
     if (hStepSumLengthOnGas1) hStepSumLengthOnGas1->Fill(aTLInGas1);
     if (hStepSumLengthOnGas2) hStepSumLengthOnGas2->Fill(aTLInGas2);
     if (hTotELossOnGas1) hTotELossOnGas1->Fill(aEnergyInGas1);
@@ -535,7 +518,7 @@ void ActarSimROOTAnalGas::UserSteppingAction(const G4Step *aStep){
   G4double edep = aStep->GetTotalEnergyDeposit();
   if (edep <= 0.) return;
 
-  if(storeTrackHistosFlag == "on") {
+  if(((ActarSimROOTAnalysis*) gActarSimROOTAnalysis)->GetStoreTrackHistosFlag() == "on") {
     if(hEdepInGas && z2<300) hEdepInGas->Fill(z,edep);
     if(htrack) htrack->Fill(postPoint.x(),
 		                        postPoint.y(),
@@ -556,7 +539,7 @@ void ActarSimROOTAnalGas::UserSteppingAction(const G4Step *aStep){
 			                                      aStep->GetTotalEnergyDeposit());
   }
 
-  if(storeTracksFlag == "on") {
+  if(((ActarSimROOTAnalysis*) gActarSimROOTAnalysis)->GetStoreTracksFlag() == "on") {
     theTracks->SetXCoord(postPoint.x());
     theTracks->SetYCoord(postPoint.y());
     theTracks->SetZCoord(postPoint.z());

--- a/src/ActarSimROOTAnalysis.cc
+++ b/src/ActarSimROOTAnalysis.cc
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez-Pol
 //*-- Date: 03/2005
-//*-- Last Update: 07/01/15
+//*-- Last Update: 14/06/16
 // --------------------------------------------------------------
 // Description:
 //   ROOT-based analysis functionality
@@ -105,11 +105,11 @@ ActarSimROOTAnalysis::ActarSimROOTAnalysis():
   silRingAnal = 0;
   sciAnal = 0;
   sciRingAnal = 0;
-  plaAnal = 0;	  
+  plaAnal = 0;
 
   gasAnalIncludedFlag = 0;
   silAnalIncludedFlag = 0;
-  silRingAnalIncludedFlag = 0;	
+  silRingAnalIncludedFlag = 0;
   sciAnalIncludedFlag = 0;
   sciRingAnalIncludedFlag = 0;
   plaAnalIncludedFlag = 0;
@@ -166,28 +166,24 @@ void ActarSimROOTAnalysis::InitAnalysisForExistingDetectors() {
   //set before (then, should be null as they are defined in the constructor)
 
   if(gasAnalIncludedFlag && !gasAnal)
-    gasAnal = new ActarSimROOTAnalGas(storeTracksFlag, storeTrackHistosFlag,
-                                      storeEventsFlag, storeSimpleTracksFlag);
-  else if(gasAnalIncludedFlag)
-    gasAnal->SetStoreFlags(storeTracksFlag, storeTrackHistosFlag,
-                           storeEventsFlag, storeSimpleTracksFlag);
+    gasAnal = new ActarSimROOTAnalGas();
 
   if(silAnalIncludedFlag && !silAnal)
     silAnal = new ActarSimROOTAnalSil();
-	
+
 	if(silRingAnalIncludedFlag && !silRingAnal)
 		silRingAnal = new ActarSimROOTAnalSilRing();
 
   if(sciAnalIncludedFlag && !sciAnal)
     sciAnal = new ActarSimROOTAnalSci();
-    
+
     if(sciRingAnalIncludedFlag && !sciRingAnal)
         sciRingAnal = new ActarSimROOTAnalSciRing();
-  
-	
+
+
   if(plaAnalIncludedFlag && !plaAnal)
     plaAnal = new ActarSimROOTAnalPla();
- 
+
 
   //OTHER DETECTORS ANALYSIS SHOULD BE INCLUDED HERE
 
@@ -244,20 +240,20 @@ void ActarSimROOTAnalysis::GenerateBeam(const G4Event *anEvent){
 //
 // Defining any beam related histogram or information in the output file
 //
-
   if(anEvent) {;} //silent the compiler.
 }
 
 
 //TODO Change from this to a GeneratePrimaries(anEvent, beamInfo)
+//DEPRECATED!!!!! DO NOT USE
 void ActarSimROOTAnalysis::GeneratePrimaries(const G4Event *anEvent,
 						G4double Theta1,
 						G4double Theta2,
 						G4double Energy1,
 						G4double Energy2) {
-
-
+//DEPRECATED!!!!! DO NOT USE
   if (gSystem) gSystem->ProcessEvents();
+  SetTheEventID(anEvent->GetEventID());
 
   //TODO->Remove this assymetry!!! There should be only one GeneratePrimaries
   //and all information should come in objects, nor arguments!!!!
@@ -282,9 +278,6 @@ void ActarSimROOTAnalysis::GeneratePrimaries(const G4Event *anEvent,
 
   //Let us create and fill as many ActarSimPrimaryInfo as primaries in the event
   thePrimaryInfo = new ActarSimPrimaryInfo*[totalPrimaries];
-
-  //Let us create and fill as many ActarSimPrimaryInfo as primaries in the event
-  //thePrimaryInfo = new ActarSimPrimaryInfo*[totalPrimaries];
 
   for(G4int i=0;i<nbOfPrimaryVertex;i++) {
     for(G4int j=0;j<nbOfPrimaries[i];j++) {
@@ -319,7 +312,7 @@ void ActarSimROOTAnalysis::GeneratePrimaries(const G4Event *anEvent,
 
   if(gasAnal) gasAnal->GeneratePrimaries(anEvent);
   if(silAnal) silAnal->GeneratePrimaries(anEvent);
-  if(silRingAnal) silRingAnal->GeneratePrimaries(anEvent); 
+  if(silRingAnal) silRingAnal->GeneratePrimaries(anEvent);
   if(sciAnal) sciAnal->GeneratePrimaries(anEvent);
   if(sciRingAnal) sciRingAnal->GeneratePrimaries(anEvent);
   if(plaAnal) plaAnal->GeneratePrimaries(anEvent);
@@ -330,10 +323,9 @@ void ActarSimROOTAnalysis::GeneratePrimaries(const G4Event *anEvent,
 
 void ActarSimROOTAnalysis::GeneratePrimaries(const G4Event *anEvent, ActarSimBeamInfo *beamInfo) {
 
-
   if (gSystem) gSystem->ProcessEvents();
+  SetTheEventID(anEvent->GetEventID());
 
-  //DPLoureiro
   Double_t aTheta1 = beamInfo->GetThetaEntrance() / deg;   // in [deg]
   Double_t aTheta2 = beamInfo->GetThetaVertex() / deg;   // in [deg]
   Double_t aEnergy1 = beamInfo->GetEnergyEntrance() / MeV; // in [MeV]
@@ -345,7 +337,6 @@ void ActarSimROOTAnalysis::GeneratePrimaries(const G4Event *anEvent, ActarSimBea
   G4int totalPrimaries = 0;
 
   for(G4int nbVertexes = 0 ; nbVertexes < nbOfPrimaryVertex ; nbVertexes++){
-
     nbOfPrimaries[nbVertexes] = anEvent->GetPrimaryVertex(nbVertexes)->GetNumberOfParticle();
     totalPrimaries += nbOfPrimaries[nbVertexes];
   }
@@ -395,7 +386,7 @@ void ActarSimROOTAnalysis::GeneratePrimaries(const G4Event *anEvent, ActarSimBea
 
   if(gasAnal) gasAnal->GeneratePrimaries(anEvent);
   if(silAnal) silAnal->GeneratePrimaries(anEvent);
-  if(silRingAnal) silRingAnal->GeneratePrimaries(anEvent); 
+  if(silRingAnal) silRingAnal->GeneratePrimaries(anEvent);
   if(sciAnal) sciAnal->GeneratePrimaries(anEvent);
   if(sciRingAnal) sciRingAnal->GeneratePrimaries(anEvent);
   if(plaAnal) plaAnal->GeneratePrimaries(anEvent);
@@ -509,10 +500,10 @@ void ActarSimROOTAnalysis::BeginOfRunAction(const G4Run *aRun) {
   //calling the actions defined for each detector
   if(gasAnal) gasAnal->BeginOfRunAction(aRun);
   if(silAnal) silAnal->BeginOfRunAction(aRun);
-  if(silRingAnal) silRingAnal->BeginOfRunAction(aRun);	
+  if(silRingAnal) silRingAnal->BeginOfRunAction(aRun);
   if(sciAnal) sciAnal->BeginOfRunAction(aRun);
   if(sciRingAnal) sciRingAnal->BeginOfRunAction(aRun);
-  if(plaAnal) plaAnal->BeginOfRunAction(aRun);	
+  if(plaAnal) plaAnal->BeginOfRunAction(aRun);
 
   simFile->cd();
 
@@ -552,7 +543,7 @@ void ActarSimROOTAnalysis::BeginOfEventAction(const G4Event *anEvent){
   //calling the actions defined for each detector
   if(gasAnal) gasAnal->BeginOfEventAction(anEvent);
   if(silAnal) silAnal->BeginOfEventAction(anEvent);
-  if(silRingAnal) silRingAnal->BeginOfEventAction(anEvent);	
+  if(silRingAnal) silRingAnal->BeginOfEventAction(anEvent);
   if(sciAnal) sciAnal->BeginOfEventAction(anEvent);
   if(sciAnal) sciAnal->BeginOfEventAction(anEvent);
   if(plaAnal) plaAnal->BeginOfEventAction(anEvent);
@@ -620,9 +611,9 @@ void ActarSimROOTAnalysis::EndOfEventAction(const G4Event *anEvent) {
   //ActarSimSilGeantHitsCollection* hitsCollection =
   // (ActarSimSilGeantHitsCollection*) HCofEvent->GetHC(hitsCollectionID);
   //Number of ActarSimSilGeantHit (or steps) in the hitsCollection
-  //G4int NbHits = hitsCollection->entries(); 
+  //G4int NbHits = hitsCollection->entries();
   //G4cout<<"Hits in the silicon "<< NbHits <<G4endl;
-  //if(NbHits){ 
+  //if(NbHits){
   //G4cout<<"ActarSimROOTAnalysis----> EndOfEventAction() "<<gasAnal<<G4endl;
   if(gasAnal) gasAnal->EndOfEventAction(anEvent);
   if(silAnal) silAnal->EndOfEventAction(anEvent);
@@ -632,6 +623,7 @@ void ActarSimROOTAnalysis::EndOfEventAction(const G4Event *anEvent) {
   if(plaAnal) plaAnal->EndOfEventAction(anEvent);
 
   eventTree->Fill();
+  primaryInfoCA->Clear(); //needed to avoid duplication of the CA contents in odd events
   //}
   OnceAWhileDoIt();
 
@@ -714,7 +706,7 @@ void ActarSimROOTAnalysis::UserSteppingAction(const G4Step *aStep){
   if(silRingAnal) silRingAnal->UserSteppingAction(aStep);
   if(sciAnal) sciAnal->UserSteppingAction(aStep);
   if(sciRingAnal) sciRingAnal->UserSteppingAction(aStep);
-  if(plaAnal) plaAnal->UserSteppingAction(aStep);	
+  if(plaAnal) plaAnal->UserSteppingAction(aStep);
 
   // Processing the beam, in case of beamInteractionFlag on
   // If a beam ion is being tracked with status 1 (ion beam being tracked) and if the present
@@ -774,7 +766,7 @@ void ActarSimROOTAnalysis::OnceAWhileDoIt(const G4bool DoItNow) {
 }
 
 //DPL 29NOV2012
-void ActarSimROOTAnalysis::SetMinStrideLength(Double_t value){ 
+void ActarSimROOTAnalysis::SetMinStrideLength(Double_t value){
   if(gasAnal)
     gasAnal->SetMinStrideLength(value);
 }


### PR DESCRIPTION
… minor corrections.

Several flags were duplicated in ActarSimROOTAnalGas and their value was not properly set by the Messenger. Now the flags
are only set in ActarSimROOTAnalysis class and the value used (via the global pointer) in other daughter classes.
Also it corrects a duplication in the primaryInfo TClonesArray in the TTree, which now is solved by calling a Clear()
just after filling the The_ACTAR_Event_Tree TTree.
