### PR TITLE
Correct data structure and the filling of data members for ancillary …

### DIFF
--- a/include/ActarSimPlaDetectorConstruction.hh
+++ b/include/ActarSimPlaDetectorConstruction.hh
@@ -26,20 +26,20 @@ class G4Material;
 //class ActarSimPlaDetectorMessenger;
 class ActarSimDetectorConstruction;
 
-class ActarSimPlaDetectorConstruction {  
+class ActarSimPlaDetectorConstruction {
 private:
-  
+
   // Materials
   G4Material* plaBulkMaterial;
- 
+
 //  ActarSimPlaDetectorMessenger* plaMessenger;   //pointer to the Messenger
   ActarSimDetectorConstruction* detConstruction;//pointer to the global detector
-  
+
   G4VPhysicalVolume* ConstructPla(G4LogicalVolume*);
 
   G4int sideCoverage;   // 6 bits to indicate which sci wall is present (1) or absent (0)
 			// order is:
-			// bit1 (lsb) beam output wall 
+			// bit1 (lsb) beam output wall
 			// bit2 lower (gravity based) wall
 			// bit3 upper (gravity based) wall
 			// bit4 left (from beam point of view) wall
@@ -52,10 +52,10 @@ private:
   G4double zBoxPlaHalfLength;   // Remember: z is along beam
 
 public:
-  
+
   ActarSimPlaDetectorConstruction(ActarSimDetectorConstruction*);
   ~ActarSimPlaDetectorConstruction();
-  
+
   G4VPhysicalVolume* Construct(G4LogicalVolume*);
 
   void SetPlaBulkMaterial (G4String);
@@ -76,4 +76,3 @@ public:
 
 };
 #endif
-

--- a/include/ActarSimPlaGeantHit.hh
+++ b/include/ActarSimPlaGeantHit.hh
@@ -1,10 +1,10 @@
 /////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez Pol
 //*-- Date: 04/2008
-//*-- Last Update: 16/12/14 by Hector Alvarez
+//*-- Last Update: 15/06/16 by Hector Alvarez
 // --------------------------------------------------------------
 // Description:
-//   A Geant Hit in the plastic (scintillator) volume. It 
+//   A Geant Hit in the plastic (scintillator) volume. It
 //  represents the information of each step with energy deposited.
 //
 // --------------------------------------------------------------
@@ -42,8 +42,7 @@ class ActarSimPlaGeantHit : public G4VHit
   G4String      postDetName;  //name of the volume at the previous step
   G4String      preDetName; //name of the volume at the following step
   G4int         detID;      //ID (copy) of the detector where the interaction takes place
-  G4ThreeVector detCenterCoordinate; // center of the present plastic, dypang 090130
-	
+
   G4double      toF;        //ToF of the interaction (postStep)
 
   G4int         trackID;    //trackID
@@ -70,8 +69,7 @@ public:
 
   void SetEdep(G4double de){ edep = de; }
 	void SetEBeforeSil(G4double eb){eBeforePla = eb;}
-	void SetEAfterSil(G4double ea){eAfterPla = ea;}	
-	
+	void SetEAfterSil(G4double ea){eAfterPla = ea;}
 
   void SetPos(G4ThreeVector xyz){ pos = xyz; }
   void SetPrePos(G4ThreeVector xyz){ prePos = xyz; }
@@ -82,7 +80,6 @@ public:
   void SetPreDetName(G4String Name){ preDetName = Name; }
   void SetPostDetName(G4String Name){ postDetName = Name; }
   void SetDetID(G4int id){ detID = id; }
-  void SetDetCenterCoordinate(G4ThreeVector center){detCenterCoordinate=center; } // center of the present plastic, dypang 090130
 
   void SetToF(G4double Time){ toF = Time; }
 
@@ -106,7 +103,6 @@ public:
   G4String      GetPreDetName(){ return preDetName; }
   G4String      GetPostDetName(){ return postDetName; }
   G4int         GetDetID(){ return detID; }
-  G4ThreeVector GetDetCenterCoordinate(){return detCenterCoordinate; } // center of the present plastic, dypang 090130
 
   G4double      GetToF(){ return toF; }
 
@@ -135,4 +131,3 @@ inline void ActarSimPlaGeantHit::operator delete(void *aHit)
   ActarSimPlaGeantHitAllocator.FreeSingle((ActarSimPlaGeantHit*) aHit);
 }
 #endif
-

--- a/include/ActarSimPlaHit.hh
+++ b/include/ActarSimPlaHit.hh
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez Pol
 //*-- Date: 04/2008
-//*-- Last Update: 16/12/14 by Hector Alvarez
+//*-- Last Update: 15/06/16 by Hector Alvarez
 // --------------------------------------------------------------
 // Description:
 //   A plastic (scintillator) hit:
@@ -23,21 +23,14 @@ class ActarSimPlaHit : public TObject{
 
 private:
 
-  //Crystal identification
-  //UInt_t type;           //crystal type
-  //UInt_t copy;           //crystal copy
-	
   // Y. Ayyad We just add the same information as Silicon to identify the scintillator bar
   //Basic Hit information
   Int_t detectorID;    // Tracker model (depends on tracker geo)
-  //Double_t detCenterCoordinateX; // center of the present silicon, dypang 090130
-  //Double_t detCenterCoordinateY; // center of the present silicon, dypang 090130
-  //Double_t detCenterCoordinateZ; // center of the present silicon, dypang 090130
 
   //Basic Hit information
   Double_t xpos;
   Double_t ypos;
-  Double_t zpos;	
+  Double_t zpos;
 
   Double_t time;    // pulse time (w.r.t. vertex emission)
   Double_t energy;  // total energy deposited
@@ -58,23 +51,17 @@ private:
 public:
   ActarSimPlaHit();
   ~ActarSimPlaHit();
-	
+
   void SetDetectorID(Int_t det){detectorID = det;}
-  //void SetDetCenterCoordinateX(Double_t x){detCenterCoordinateX=x;} // center of the present silicon, dypang 090130
-  //void SetDetCenterCoordinateY(Double_t y){detCenterCoordinateY=y;} // center of the present silicon, dypang 090130
-  //void SetDetCenterCoordinateZ(Double_t z){detCenterCoordinateZ=z;} // center of the present silicon, dypang 090130
   void SetXPos(Double_t x){xpos = x;}
   void SetYPos(Double_t y){ypos = y;}
   void SetZPos(Double_t z){zpos = z;}
-
-  //void SetType(UInt_t ty){type = ty;}
-  //void SetCopy(UInt_t co){copy = co;}
 
   void SetTime(Double_t ti){time = ti;}
   void SetEnergy(Double_t ed){energy = ed;}
   void SetEBeforePla(Double_t eb){eBeforePla = eb;}
   void SetEAfterPla(Double_t ea){eAfterPla = ea;}
-	
+
   void SetEventID(UInt_t ev){eventID = ev;}
   void SetRunID(UInt_t run){runID = run;}
   void SetTrackID(UInt_t track){trackID = track;}
@@ -87,15 +74,9 @@ public:
 
   Int_t GetDetectorID(){return detectorID;}
 
-  //Double_t GetDetCenterCoordinateX(){return detCenterCoordinateX;} // center of the present silicon, dypang 090130
-  //Double_t GetDetCenterCoordinateY(){return detCenterCoordinateY;} // center of the present silicon, dypang 090130
-  //Double_t GetDetCenterCoordinateZ(){return detCenterCoordinateZ;} // center of the present silicon, dypang 090130
   Double_t GetXPos(){return xpos;}
   Double_t GetYPos(){return ypos;}
   Double_t GetZPos(){return zpos;}
-	
-  //Int_t GetType(){return type;}
-  //Int_t GetCopy(){return copy;}
 
   Double_t GetEnergy(){return energy;}
   Double_t GetTime(){return time;}
@@ -110,7 +91,7 @@ public:
   Double_t GetParticleCharge(){return particleCharge;}
   Double_t GetParticleMass(){return particleMass;}
 
-  UInt_t GetStepsContributing(){return stepsContributing;}	
+  UInt_t GetStepsContributing(){return stepsContributing;}
 
   void print(void);
 

--- a/include/ActarSimSilGeantHit.hh
+++ b/include/ActarSimSilGeantHit.hh
@@ -42,7 +42,6 @@ class ActarSimSilGeantHit : public G4VHit
   G4String      postDetName;  //name of the volume at the previous step
   G4String      preDetName;    //name of the volume at the following step
   G4int         detID;   //ID (copy) of the detector where the interaction takes place
-  G4ThreeVector detCenterCoordinate; // center of the present silicon, dypang 090130
 
   G4double      toF;     //ToF of the interaction (postStep)
 
@@ -81,7 +80,6 @@ public:
   void SetPreDetName(G4String Name){ preDetName = Name; }
   void SetPostDetName(G4String Name){ postDetName = Name; }
   void SetDetID(G4int id){ detID = id; }
-  void SetDetCenterCoordinate(G4ThreeVector center){detCenterCoordinate=center; } // center of the present silicon, dypang 090130
 
   void SetToF(G4double Time){ toF = Time; }
 
@@ -104,7 +102,6 @@ public:
   G4String      GetPreDetName(){ return preDetName; }
   G4String      GetPostDetName(){ return postDetName; }
   G4int         GetDetID(){ return detID; }
-  G4ThreeVector GetDetCenterCoordinate(){return detCenterCoordinate; } // center of the present silicon, dypang 090130
 
   G4double      GetToF(){ return toF; }
 
@@ -132,4 +129,3 @@ inline void ActarSimSilGeantHit::operator delete(void *aHit)
   ActarSimSilGeantHitAllocator.FreeSingle((ActarSimSilGeantHit*) aHit);
 }
 #endif
-

--- a/include/ActarSimSilHit.hh
+++ b/include/ActarSimSilHit.hh
@@ -25,9 +25,6 @@ private:
 
   //Basic Hit information
   Int_t detectorID;    // Tracker model (depends on tracker geo)
-  Double_t detCenterCoordinateX; // center of the present silicon, dypang 090130
-  Double_t detCenterCoordinateY; // center of the present silicon, dypang 090130
-  Double_t detCenterCoordinateZ; // center of the present silicon, dypang 090130
 
   //Basic Hit information
   Double_t xpos;
@@ -56,10 +53,6 @@ public:
 
   void SetDetectorID(Int_t det){detectorID = det;}
 
-  void SetDetCenterCoordinateX(Double_t x){detCenterCoordinateX=x;} // center of the present silicon, dypang 090130
-  void SetDetCenterCoordinateY(Double_t y){detCenterCoordinateY=y;} // center of the present silicon, dypang 090130
-  void SetDetCenterCoordinateZ(Double_t z){detCenterCoordinateZ=z;} // center of the present silicon, dypang 090130
-
   void SetXPos(Double_t x){xpos = x;}
   void SetYPos(Double_t y){ypos = y;}
   void SetZPos(Double_t z){zpos = z;}
@@ -80,10 +73,6 @@ public:
   void SetStepsContributing(UInt_t step){stepsContributing = step;}
 
   Int_t GetDetectorID(){return detectorID;}
-
-  Double_t GetDetCenterCoordinateX(){return detCenterCoordinateX;} // center of the present silicon, dypang 090130
-  Double_t GetDetCenterCoordinateY(){return detCenterCoordinateY;} // center of the present silicon, dypang 090130
-  Double_t GetDetCenterCoordinateZ(){return detCenterCoordinateZ;} // center of the present silicon, dypang 090130
 
   Double_t GetXPos(){return xpos;}
   Double_t GetYPos(){return ypos;}

--- a/include/ActarSimSilRingGeantHit.hh
+++ b/include/ActarSimSilRingGeantHit.hh
@@ -42,7 +42,6 @@ class ActarSimSilRingGeantHit : public G4VHit
   G4String      postDetName;  //name of the volume at the previous step
   G4String      preDetName;    //name of the volume at the following step
   G4int         detID;   //ID (copy) of the detector where the interaction takes place
-  G4ThreeVector detCenterCoordinate; // center of the present silicon, dypang 090130
 
   G4double      toF;     //ToF of the interaction (postStep)
 
@@ -81,7 +80,6 @@ public:
   void SetPreDetName(G4String Name){ preDetName = Name; }
   void SetPostDetName(G4String Name){ postDetName = Name; }
   void SetDetID(G4int id){ detID = id; }
-  void SetDetCenterCoordinate(G4ThreeVector center){detCenterCoordinate=center; } // center of the present silicon, dypang 090130
 
   void SetToF(G4double Time){ toF = Time; }
 
@@ -104,7 +102,6 @@ public:
   G4String      GetPreDetName(){ return preDetName; }
   G4String      GetPostDetName(){ return postDetName; }
   G4int         GetDetID(){ return detID; }
-  G4ThreeVector GetDetCenterCoordinate(){return detCenterCoordinate; } // center of the present silicon, dypang 090130
 
   G4double      GetToF(){ return toF; }
 
@@ -132,4 +129,3 @@ inline void ActarSimSilRingGeantHit::operator delete(void *aHit)
   ActarSimSilRingGeantHitAllocator.FreeSingle((ActarSimSilRingGeantHit*) aHit);
 }
 #endif
-

--- a/include/ActarSimSilRingHit.hh
+++ b/include/ActarSimSilRingHit.hh
@@ -25,9 +25,6 @@ private:
 
   //Basic Hit information
   Int_t detectorID;    // Tracker model (depends on tracker geo)
-  Double_t detCenterCoordinateX; // center of the present silicon, dypang 090130
-  Double_t detCenterCoordinateY; // center of the present silicon, dypang 090130
-  Double_t detCenterCoordinateZ; // center of the present silicon, dypang 090130
 
   //Basic Hit information
   Double_t xpos;
@@ -56,10 +53,6 @@ public:
 
   void SetDetectorID(Int_t det){detectorID = det;}
 
-  void SetDetCenterCoordinateX(Double_t x){detCenterCoordinateX=x;} // center of the present silicon, dypang 090130
-  void SetDetCenterCoordinateY(Double_t y){detCenterCoordinateY=y;} // center of the present silicon, dypang 090130
-  void SetDetCenterCoordinateZ(Double_t z){detCenterCoordinateZ=z;} // center of the present silicon, dypang 090130
-
   void SetXPos(Double_t x){xpos = x;}
   void SetYPos(Double_t y){ypos = y;}
   void SetZPos(Double_t z){zpos = z;}
@@ -80,10 +73,6 @@ public:
   void SetStepsContributing(UInt_t step){stepsContributing = step;}
 
   Int_t GetDetectorID(){return detectorID;}
-
-  Double_t GetDetCenterCoordinateX(){return detCenterCoordinateX;} // center of the present silicon, dypang 090130
-  Double_t GetDetCenterCoordinateY(){return detCenterCoordinateY;} // center of the present silicon, dypang 090130
-  Double_t GetDetCenterCoordinateZ(){return detCenterCoordinateZ;} // center of the present silicon, dypang 090130
 
   Double_t GetXPos(){return xpos;}
   Double_t GetYPos(){return ypos;}

--- a/src/ActarSimPlaDetectorConstruction.cc
+++ b/src/ActarSimPlaDetectorConstruction.cc
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez
 //*-- Date: 04/2008
-//*-- Last Update: 16/12/14 by Hector Alvarez
+//*-- Last Update: 15/06/16 by Hector Alvarez
 // --------------------------------------------------------------
 // Description:
 //   Scintillator plastic detector description
@@ -45,12 +45,8 @@ ActarSimPlaDetectorConstruction(ActarSimDetectorConstruction* det)
   // Constructor. Sets the material and the pointer to the Messenger
   //
 
-
   SetPlaBulkMaterial("BC408");
-
-
   SetSideCoverage(1);
-
   SetXBoxPlaHalfLength(100*cm);
   SetYBoxPlaHalfLength(100*cm);
   SetZBoxPlaHalfLength(100*cm);
@@ -59,14 +55,12 @@ ActarSimPlaDetectorConstruction(ActarSimDetectorConstruction* det)
   //plaMessenger = new ActarSimPlaDetectorMessenger(this);
 }
 
-
 ActarSimPlaDetectorConstruction::~ActarSimPlaDetectorConstruction(){
   //
   // Destructor
   //
  // delete plaMessenger;
 }
-
 
 G4VPhysicalVolume* ActarSimPlaDetectorConstruction::Construct(G4LogicalVolume* worldLog) {
   //
@@ -79,12 +73,8 @@ G4VPhysicalVolume* ActarSimPlaDetectorConstruction::Construct(G4LogicalVolume* w
   return ConstructPla(worldLog);
 }
 
-
-
 G4VPhysicalVolume* ActarSimPlaDetectorConstruction::ConstructPla(G4LogicalVolume* worldLog) {
-
   //
-
   //Chamber Y,Z length
   //G4double chamberSizeY=detConstruction->GetChamberYLength();
   G4double chamberSizeZ=detConstruction->GetChamberSizeZ();
@@ -93,22 +83,19 @@ G4VPhysicalVolume* ActarSimPlaDetectorConstruction::ConstructPla(G4LogicalVolume
   ActarSimGasDetectorConstruction* gasDet = detConstruction->GetGasDetector();
   G4double zGasBoxPosition=gasDet->GetGasBoxCenterZ();
 
-
     //Hodo Box
 	G4double hodo_x=105*cm;
 	G4double hodo_y=105*cm;
 	G4double hodo_z=60.0*cm;
 
-
   G4double plaBulk_x = 9.95*mm;   //half length=12.5mm
   G4double plaBulk_y = 100*mm;   //half length=12.5mm
   G4double plaBulk_z = 5.0*mm;   //half length=15.0mm
 
-
 	//the numbers
 	G4double nDE=13; //number of Scint in dE
 	G4double nE1=16; //number of Scint in E1
-	G4double nE2=13;//number of Scint in E2
+	G4double nE2=13; //number of Scint in E2
 	//G4double nTarget=1;//number of Targets
 
 	//G4double yHodo=chamberSizeY/2-1*mm;
@@ -135,7 +122,6 @@ G4VPhysicalVolume* ActarSimPlaDetectorConstruction::ConstructPla(G4LogicalVolume
 	 << G4endl;
   G4cout << "##################################################################"
 	 << G4endl;*/
-
 
   G4LogicalVolume* plaLog(0);
   G4VPhysicalVolume* plaPhys(0);
@@ -179,11 +165,6 @@ G4VPhysicalVolume* ActarSimPlaDetectorConstruction::ConstructPla(G4LogicalVolume
 
 	G4VisAttributes* logicBar_VisAtt = new G4VisAttributes(G4Colour(0.7,1.0,0.0));
 	plaLog->SetVisAttributes(logicBar_VisAtt);
-
-
-
-
-
 
   //------------------------------------------------
   // Sensitive detectors

--- a/src/ActarSimPlaGeantHit.cc
+++ b/src/ActarSimPlaGeantHit.cc
@@ -1,10 +1,10 @@
 /////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez Pol
 //*-- Date: 04/2008
-//*-- Last Update: 16/12/14 by Hector Alvarez
+//*-- Last Update: 15/06/16 by Hector Alvarez
 // --------------------------------------------------------------
 // Description:
-//   A Geant Hit in the plastic (scintillator) volume. It 
+//   A Geant Hit in the plastic (scintillator) volume. It
 //  represents the information of each step with energy deposited.
 //
 // --------------------------------------------------------------
@@ -23,20 +23,17 @@
 
 G4Allocator<ActarSimPlaGeantHit> ActarSimPlaGeantHitAllocator;
 
-
 ActarSimPlaGeantHit::ActarSimPlaGeantHit() {
   //
   // Constructor
   //
 }
 
-
 ActarSimPlaGeantHit::~ActarSimPlaGeantHit() {
   //
   // Destructor
   //
 }
-
 
 ActarSimPlaGeantHit::ActarSimPlaGeantHit(const ActarSimPlaGeantHit& right) : G4VHit() {
   //
@@ -53,16 +50,13 @@ ActarSimPlaGeantHit::ActarSimPlaGeantHit(const ActarSimPlaGeantHit& right) : G4V
 	postDetName = right.postDetName;
 	preDetName = right.preDetName;
 	detID = right.detID;
-	detCenterCoordinate = right.detCenterCoordinate; // center of the present silicon, dypang 090130
 	toF = right.toF;
 	trackID = right.trackID;
 	parentID = right.parentID;
 	particleID = right.particleID;
 	particleCharge = right.particleCharge;
 	particleMass = right.particleMass;
-	
 }
-
 
 const ActarSimPlaGeantHit& ActarSimPlaGeantHit::operator=(const ActarSimPlaGeantHit& right){
   //
@@ -79,18 +73,14 @@ const ActarSimPlaGeantHit& ActarSimPlaGeantHit::operator=(const ActarSimPlaGeant
 	postDetName = right.postDetName;
 	preDetName = right.preDetName;
 	detID = right.detID;
-	detCenterCoordinate = right.detCenterCoordinate; // center of the present silicon, dypang 090130
 	toF = right.toF;
 	trackID = right.trackID;
 	parentID = right.parentID;
 	particleID = right.particleID;
 	particleCharge = right.particleCharge;
 	particleMass = right.particleMass;
-	
 	return *this;
-	
 }
-
 
 G4int ActarSimPlaGeantHit::operator==(const ActarSimPlaGeantHit& right) const{
   //
@@ -98,7 +88,6 @@ G4int ActarSimPlaGeantHit::operator==(const ActarSimPlaGeantHit& right) const{
   //
   return (this==&right) ? 1 : 0;
 }
-
 
 void ActarSimPlaGeantHit::Draw(){
   //
@@ -116,7 +105,6 @@ void ActarSimPlaGeantHit::Draw(){
     pVVisManager->Draw(circle);
   }
 }
-
 
 void ActarSimPlaGeantHit::Print(){
   //
@@ -143,7 +131,3 @@ void ActarSimPlaGeantHit::Print(){
 	 << G4endl;
 
 }
-
-
-
-

--- a/src/ActarSimROOTAnalPla.cc
+++ b/src/ActarSimROOTAnalPla.cc
@@ -438,10 +438,6 @@ void ActarSimROOTAnalPla::AddCalPlaHit(ActarSimPlaHit* cHit,
 
 	  cHit->SetDetectorID(gHit->GetDetID());
 
-	  //cHit->SetDetCenterCoordinateX(gHit->GetDetCenterCoordinate().x()/mm); // center of the present silicon, dypang 090130
-	  //cHit->SetDetCenterCoordinateY(gHit->GetDetCenterCoordinate().y()/mm); // center of the present silicon, dypang 090130
-	  //cHit->SetDetCenterCoordinateZ(gHit->GetDetCenterCoordinate().z()/mm); // center of the present silicon, dypang 090130
-
 	  cHit->SetXPos(gHit->GetLocalPrePos().x()/mm);
 	  cHit->SetYPos(gHit->GetLocalPrePos().y()/mm);
 	  cHit->SetZPos(gHit->GetLocalPrePos().z()/mm);
@@ -510,6 +506,10 @@ void ActarSimROOTAnalPla::AddCalPlaHit(ActarSimPlaHit* cHit,
   }
   else if(mode==1){ //addition
     cHit->SetEnergy(cHit->GetEnergy() + gHit->GetEdep()/ MeV);
+    //taking the smaller outgoing energy of the geantHits
+    if(cHit->GetEAfterPla()>gHit->GetEAfterPla()) cHit->SetEAfterPla(gHit->GetEAfterPla()/MeV);
+    //taking the larger incoming energy of the geantHits
+    if(cHit->GetEBeforePla()<gHit->GetEBeforePla()) cHit->SetEBeforePla(gHit->GetEBeforePla()/MeV);
 
 	  cHit->SetStepsContributing(cHit->GetStepsContributing()+1);
 	  // The mean value of a distribution {x_i} can also be computed iteratively
@@ -522,10 +522,8 @@ void ActarSimROOTAnalPla::AddCalPlaHit(ActarSimPlaHit* cHit,
 	  cHit->SetZPos(cHit->GetZPos() +
 					(gHit->GetLocalPrePos().z()-cHit->GetZPos())/((G4double)cHit->GetStepsContributing()));
 
-
-
-
-    if(gHit->GetToF()<cHit->GetTime()) cHit->SetTime(gHit->GetToF()/ ns);
+    //taking the shorter time of the geantHits
+    if(gHit->GetToF()<cHit->GetTime()) cHit->SetTime(gHit->GetToF()/ns);
 
     //TODO-> Recover here the simhit/hit duality if needed!!
 /*

--- a/src/ActarSimROOTAnalSil.cc
+++ b/src/ActarSimROOTAnalSil.cc
@@ -228,10 +228,6 @@ void ActarSimROOTAnalSil::AddSilHit(ActarSimSilHit* cHit,
   if(mode == 0) { //creation
     cHit->SetDetectorID(gHit->GetDetID());
 
-    cHit->SetDetCenterCoordinateX(gHit->GetDetCenterCoordinate().x()/mm); // center of the present silicon, dypang 090130
-    cHit->SetDetCenterCoordinateY(gHit->GetDetCenterCoordinate().y()/mm); // center of the present silicon, dypang 090130
-    cHit->SetDetCenterCoordinateZ(gHit->GetDetCenterCoordinate().z()/mm); // center of the present silicon, dypang 090130
-
     cHit->SetXPos(gHit->GetLocalPrePos().x()/mm);
     cHit->SetYPos(gHit->GetLocalPrePos().y()/mm);
     cHit->SetZPos(gHit->GetLocalPrePos().z()/mm);
@@ -255,6 +251,10 @@ void ActarSimROOTAnalSil::AddSilHit(ActarSimSilHit* cHit,
 
   else if(mode==1){ //addition
     cHit->SetEnergy(cHit->GetEnergy() + gHit->GetEdep());
+    //taking the smaller outgoing energy of the geantHits
+    if(cHit->GetEAfterSil()>gHit->GetEAfterSil()) cHit->SetEAfterSil(gHit->GetEAfterSil()/MeV);
+    //taking the larger incoming energy of the geantHits
+    if(cHit->GetEBeforeSil()<gHit->GetEBeforeSil()) cHit->SetEBeforeSil(gHit->GetEBeforeSil()/MeV);
 
     cHit->SetStepsContributing(cHit->GetStepsContributing()+1);
     // The mean value of a distribution {x_i} can also be computed iteratively
@@ -268,7 +268,7 @@ void ActarSimROOTAnalSil::AddSilHit(ActarSimSilHit* cHit,
 		  (gHit->GetLocalPrePos().z()-cHit->GetZPos())/((G4double)cHit->GetStepsContributing()));
 
     //taking the shorter time of the geantHits
-    if(cHit->GetTime()>gHit->GetToF()) cHit->SetTime(gHit->GetToF());
+    if(cHit->GetTime()>gHit->GetToF()) cHit->SetTime(gHit->GetToF()/ns);
   }
 }
 

--- a/src/ActarSimROOTAnalSilRing.cc
+++ b/src/ActarSimROOTAnalSilRing.cc
@@ -226,10 +226,6 @@ void ActarSimROOTAnalSilRing::AddSilRingHit(ActarSimSilRingHit* cHit,
   if(mode == 0) { //creation
     cHit->SetDetectorID(gHit->GetDetID());
 
-    cHit->SetDetCenterCoordinateX(gHit->GetDetCenterCoordinate().x()/mm); // center of the present silicon, dypang 090130
-    cHit->SetDetCenterCoordinateY(gHit->GetDetCenterCoordinate().y()/mm); // center of the present silicon, dypang 090130
-    cHit->SetDetCenterCoordinateZ(gHit->GetDetCenterCoordinate().z()/mm); // center of the present silicon, dypang 090130
-
     cHit->SetXPos(gHit->GetLocalPrePos().x()/mm);
     cHit->SetYPos(gHit->GetLocalPrePos().y()/mm);
     cHit->SetZPos(gHit->GetLocalPrePos().z()/mm);
@@ -253,6 +249,10 @@ void ActarSimROOTAnalSilRing::AddSilRingHit(ActarSimSilRingHit* cHit,
 
   else if(mode==1){ //addition
     cHit->SetEnergy(cHit->GetEnergy() + gHit->GetEdep());
+    //taking the smaller outgoing energy of the geantHits
+    if(cHit->GetEAfterSil()>gHit->GetEAfterSil()) cHit->SetEAfterSil(gHit->GetEAfterSil()/MeV);
+    //taking the larger incoming energy of the geantHits
+    if(cHit->GetEBeforeSil()<gHit->GetEBeforeSil()) cHit->SetEBeforeSil(gHit->GetEBeforeSil()/MeV);
 
     cHit->SetStepsContributing(cHit->GetStepsContributing()+1);
     // The mean value of a distribution {x_i} can also be computed iteratively
@@ -266,7 +266,7 @@ void ActarSimROOTAnalSilRing::AddSilRingHit(ActarSimSilRingHit* cHit,
 		  (gHit->GetLocalPrePos().z()-cHit->GetZPos())/((G4double)cHit->GetStepsContributing()));
 
     //taking the shorter time of the geantHits
-    if(cHit->GetTime()>gHit->GetToF()) cHit->SetTime(gHit->GetToF());
+    if(cHit->GetTime()>gHit->GetToF()) cHit->SetTime(gHit->GetToF()/ns);
   }
 }
 

--- a/src/ActarSimSilGeantHit.cc
+++ b/src/ActarSimSilGeantHit.cc
@@ -52,7 +52,6 @@ ActarSimSilGeantHit::ActarSimSilGeantHit(const ActarSimSilGeantHit& right) : G4V
   postDetName = right.postDetName;
   preDetName = right.preDetName;
   detID = right.detID;
-  detCenterCoordinate = right.detCenterCoordinate; // center of the present silicon, dypang 090130
   toF = right.toF;
   trackID = right.trackID;
   parentID = right.parentID;
@@ -77,7 +76,6 @@ const ActarSimSilGeantHit& ActarSimSilGeantHit::operator=(const ActarSimSilGeant
   postDetName = right.postDetName;
   preDetName = right.preDetName;
   detID = right.detID;
-  detCenterCoordinate = right.detCenterCoordinate; // center of the present silicon, dypang 090130
   toF = right.toF;
   trackID = right.trackID;
   parentID = right.parentID;
@@ -140,7 +138,3 @@ void ActarSimSilGeantHit::Print(){
 	       << G4endl;
 
 }
-
-
-
-

--- a/src/ActarSimSilHit.cc
+++ b/src/ActarSimSilHit.cc
@@ -25,10 +25,6 @@ ActarSimSilHit::ActarSimSilHit(){
 
   detectorID = 0;
 
-  detCenterCoordinateX=0.; // center of the present silicon, dypang 090130
-  detCenterCoordinateY=0.; // center of the present silicon, dypang 090130
-  detCenterCoordinateZ=0.; // center of the present silicon, dypang 090130
-
   xpos=0;
   ypos=0;
   zpos=0;
@@ -45,7 +41,7 @@ ActarSimSilHit::ActarSimSilHit(){
   particleMass=0;
 
   stepsContributing = 0;
-  
+
 }
 
 ActarSimSilHit::~ActarSimSilHit(){
@@ -62,5 +58,3 @@ void ActarSimSilHit::print(void){
 
 
 }
-
-

--- a/src/ActarSimSilRingGeantHit.cc
+++ b/src/ActarSimSilRingGeantHit.cc
@@ -53,7 +53,6 @@ ActarSimSilRingGeantHit::ActarSimSilRingGeantHit(const ActarSimSilRingGeantHit& 
   postDetName = right.postDetName;
   preDetName = right.preDetName;
   detID = right.detID;
-  detCenterCoordinate = right.detCenterCoordinate; // center of the present silicon, dypang 090130
   toF = right.toF;
   trackID = right.trackID;
   parentID = right.parentID;
@@ -78,7 +77,6 @@ const ActarSimSilRingGeantHit& ActarSimSilRingGeantHit::operator=(const ActarSim
   postDetName = right.postDetName;
   preDetName = right.preDetName;
   detID = right.detID;
-  detCenterCoordinate = right.detCenterCoordinate; // center of the present silicon, dypang 090130
   toF = right.toF;
   trackID = right.trackID;
   parentID = right.parentID;
@@ -140,7 +138,3 @@ void ActarSimSilRingGeantHit::Print(){
   G4cout << "##################################################################"
 	       << G4endl;
 }
-
-
-
-

--- a/src/ActarSimSilRingHit.cc
+++ b/src/ActarSimSilRingHit.cc
@@ -24,11 +24,7 @@ ActarSimSilRingHit::ActarSimSilRingHit(){
   //
 
   detectorID = 0;
-
-  detCenterCoordinateX=0.; // center of the present silicon, dypang 090130
-  detCenterCoordinateY=0.; // center of the present silicon, dypang 090130
-  detCenterCoordinateZ=0.; // center of the present silicon, dypang 090130
-
+  
   xpos=0;
   ypos=0;
   zpos=0;
@@ -61,5 +57,3 @@ void ActarSimSilRingHit::print(void){
 
 
 }
-
-

--- a/src/ActarSimSilRingSD.cc
+++ b/src/ActarSimSilRingSD.cc
@@ -95,7 +95,6 @@ G4bool ActarSimSilRingSD::ProcessHits(G4Step* aStep,G4TouchableHistory*){
   newHit->SetPreDetName(aStep->GetPreStepPoint()->GetPhysicalVolume()->GetName());
   newHit->SetPostDetName(aStep->GetPostStepPoint()->GetPhysicalVolume()->GetName());
   newHit->SetDetID(aStep->GetTrack()->GetVolume()->GetCopyNo());
-  newHit->SetDetCenterCoordinate(aStep->GetTrack()->GetVolume()->GetObjectTranslation()); // center of the present silicon, dypang 090130
 
   newHit->SetToF(aStep->GetPostStepPoint()->GetGlobalTime());
 

--- a/src/ActarSimSilSD.cc
+++ b/src/ActarSimSilSD.cc
@@ -96,7 +96,6 @@ G4bool ActarSimSilSD::ProcessHits(G4Step* aStep,G4TouchableHistory*){
   newHit->SetPreDetName(aStep->GetPreStepPoint()->GetPhysicalVolume()->GetName());
   newHit->SetPostDetName(aStep->GetPostStepPoint()->GetPhysicalVolume()->GetName());
   newHit->SetDetID(aStep->GetTrack()->GetVolume()->GetCopyNo());
-  newHit->SetDetCenterCoordinate(aStep->GetTrack()->GetVolume()->GetObjectTranslation()); // center of the present silicon, dypang 090130
 
   newHit->SetToF(aStep->GetPostStepPoint()->GetGlobalTime());
 


### PR DESCRIPTION
…detectors.

Different errors in the filling of the data members of ancillary detector hits have been corrected,
as errors filling the energy after the silicons, specify timing in ns and removing centerOfDetectors
datamember which is not a hit variable but a constant per detector.
