### PR TITLE
Correct Tree branches and filling.

### DIFF
--- a/include/ActarSimBeamInfo.hh
+++ b/include/ActarSimBeamInfo.hh
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez-Pol
 //*-- Date: 06/2008
-//*-- Last Update: 1/12/14 by Hector Alvarez
+//*-- Last Update: 20/06/16 by Hector Alvarez
 // --------------------------------------------------------------
 // Description:
 //   The information from the beam parameters used for the reaction
@@ -43,6 +43,12 @@ private:
 
   Double_t timeVertex;        // time at vertex
 
+  Double_t mass;              // mass
+  Double_t charge;            // charge
+
+  Int_t eventID;             // eventID
+  Int_t runID;               // runID
+
   Int_t status;	//! (Does not move to file!)
                 // Informs of ion beam status. Used for the dynamical vertex generation
 			          // in ActarSimPrimaryGeneratorAction.
@@ -74,6 +80,11 @@ public:
 
   inline Double_t GetTimeVertex() const { return timeVertex; }
 
+  inline Double_t GetMass() const { return mass; }
+  inline Double_t GetCharge() const { return charge; }
+  inline Double_t GetEventID() const { return eventID; }
+  inline Double_t GetRunID() const { return runID; }
+
   inline Int_t GetStatus() const { return status; }
 
   inline void SetEnergyEntrance(Double_t e) { energyEntrance = e; }
@@ -94,6 +105,11 @@ public:
   inline void SetZVertex(Double_t z) { zVertex = z; }
 
   inline void SetTimeVertex(Double_t t) { timeVertex = t; }
+
+  inline void SetMass(Double_t m) { mass = m; }
+  inline void SetCharge(Double_t c) { charge = c; }
+  inline void SetEventID(UInt_t eID) { eventID = eID; }
+  inline void SetRunID(UInt_t rID) { runID = rID; }
 
   inline void SetStatus(Int_t s) { status = s; }
 

--- a/include/ActarSimData.hh
+++ b/include/ActarSimData.hh
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez-Pol
 //*-- Date: 05/2005
-//*-- Last Update:  1/12/2015
+//*-- Last Update:  21/06/2016
 // --------------------------------------------------------------
 // Description:
 //   Data definition
@@ -16,8 +16,9 @@
 #define ActarSimData_h 1
 
 #include "TROOT.h"  //for including Rtypes.h
+#include "TObject.h"
 
-class ActarSimData{
+class ActarSimData: public TObject {
 
 private:
 

--- a/include/ActarSimROOTAnalGas.hh
+++ b/include/ActarSimROOTAnalGas.hh
@@ -34,7 +34,7 @@ class TH1D;
 class TH2D;
 class TH3D;
 class TTree;
-class TBranch;
+//class TBranch;
 class TFile;
 class TClonesArray;
 class TProfile; // for hbeamEnergyAtRange, to get the energy loss as a function of the path length
@@ -58,9 +58,9 @@ private:
   TTree* eventTree; //Tree
   TTree* tracksTree; //Tree
 
-  TBranch* dataBranch; //Local branch
-  TBranch* simpleTrackBranch; //Local branch
-  TBranch* trackBranch; //Local branch
+  //TBranch* dataBranch; //Local branch
+  //TBranch* simpleTrackBranch; //Local branch
+  //TBranch* trackBranch; //Local branch
 
   TH1D *hStepSumLengthOnGas1;   // Step Length
   TH1D *hStepSumLengthOnGas2;   // Step Length
@@ -124,12 +124,12 @@ public:
 
   void SetMinStrideLength(G4double val) {minStrideLength = val;};
 
-  TBranch* GetDataBranch(){return dataBranch;}
-  void SetDataBranch(TBranch* aBranch) {dataBranch= aBranch;}
-  TBranch* GetTrackBranch(){return trackBranch;}
-  void SetTrackBranch(TBranch* aBranch) {trackBranch= aBranch;}
-  TBranch* GetSimpleTrackBranch(){return simpleTrackBranch;}
-  void SetSimpleTrackBranch(TBranch* aBranch) {simpleTrackBranch= aBranch;}
+  //TBranch* GetDataBranch(){return dataBranch;}
+  //void SetDataBranch(TBranch* aBranch) {dataBranch= aBranch;}
+  //TBranch* GetTrackBranch(){return trackBranch;}
+  //void SetTrackBranch(TBranch* aBranch) {trackBranch= aBranch;}
+  //TBranch* GetSimpleTrackBranch(){return simpleTrackBranch;}
+  //void SetSimpleTrackBranch(TBranch* aBranch) {simpleTrackBranch= aBranch;}
 
   TClonesArray* getSimpleTrackCA(void){return simpleTrackCA;}
   void SetSimpleTrackCA(TClonesArray* CA) {simpleTrackCA = CA;}

--- a/include/ActarSimROOTAnalysis.hh
+++ b/include/ActarSimROOTAnalysis.hh
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez-Pol
 //*-- Date: 03/2005
-//*-- Last Update: 14/06/16 by hapol
+//*-- Last Update: 20/06/16 by hapol
 // --------------------------------------------------------------
 // Description:
 //   ROOT-based analysis functionality
@@ -87,8 +87,9 @@ private:
   //G4PrimaryParticle* primary;      //Storing the primary for accesing during UserStep //NOT USED
   ActarSimAnalysisMessenger* analMessenger; // pointer to messenger
 
-  TBranch* primaryInfoBranch; //Local primaries branch
-  TBranch* beamInfoBranch;    //Beam Info branch
+  //TBranch* primaryInfoBranch; // Local primaries branch
+  //TBranch* beamInfoBranch;    // Beam Info branch
+  //TBranch* theDataBranch;    // theData branch
 
   //TClonesArray*  simpleTrackCA; //NOT USED
 
@@ -111,6 +112,8 @@ private:
 
   ActarSimPrimaryInfo** thePrimaryInfo; //Primary particles data
   TClonesArray* primaryInfoCA;
+  TClonesArray* beamInfoCA;
+  TClonesArray* theDataCA;
 
   G4int theRunID; //To keep some numbers on the Tree
   G4int theEventID; //To keep some numbers on the Tree

--- a/src/ActarSimBeamInfo.cc
+++ b/src/ActarSimBeamInfo.cc
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez-Pol
 //*-- Date: 01/2006
-//*-- Last Update: 1/12/14 by Hector Alvarez
+//*-- Last Update: 20/06/16 by Hector Alvarez
 // --------------------------------------------------------------
 // Description:
 //   The information from the beam parameters used for the reaction
@@ -36,7 +36,11 @@ ActarSimBeamInfo::ActarSimBeamInfo() {
   yVertex = 0.;
   zVertex = 0.;
   timeVertex = 0.;         // time at vertex formation
-  status = 0;
+  mass = 0.0;              // mass
+  charge = 0.0;            // charge
+  eventID = 0;             // eventID
+  runID = 0;               // runID
+  status = 0;              // status
 }
 
 
@@ -69,6 +73,8 @@ void ActarSimBeamInfo::print(void){
   G4cout << " thetaVertex: " << thetaVertex / rad << " rad"
 	 << " phiVertex: " << phiVertex / rad << " rad"<< G4endl;
   G4cout << " Time at the reaction vertex:  " << timeVertex/ns << " ns" << G4endl;
+  G4cout << " Mass: " << mass
+         << ", charge: " << charge / eplus << " eplus" << G4endl;
   G4cout << " Status : " << status << G4endl;
   G4cout << "-------------------------------------------" << G4endl;
 }

--- a/src/ActarSimPrimaryGeneratorAction.cc
+++ b/src/ActarSimPrimaryGeneratorAction.cc
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////
 //*-- AUTHOR : Hector Alvarez-Pol
 //*-- Date: 11/2004
-//*-- Last Update: 04/12/15 by Hector Alvarez Pol
+//*-- Last Update: 21/06/16 by Hector Alvarez Pol
 // --------------------------------------------------------------
 // Description:
 //   Actions to perform to generate a primary vertex
@@ -208,6 +208,8 @@ void ActarSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
       // should be transformed accordingly. Fine tuning, anyway (check if needed)
       particleGun->SetParticleDefinition(incidentIon);
       particleGun->SetParticleCharge(incidentIonCharge);
+      pBeamInfo->SetCharge(incidentIonCharge);
+      pBeamInfo->SetMass(incidentIon->GetAtomicMass());
 
       // vertex_z0 decides the z position of the vertex. The beam is tracked till z0 is reached ...
       G4double vertex_z0 = 0;
@@ -862,12 +864,12 @@ void ActarSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
     }
 
     G4double thetaBeam1, thetaBeam2;
-    
+
     thetaBeam1 = KINE->GetANGAs(0);    // unit: rad
     thetaBeam2 = KINE->GetANGAr(0);    // unit: rad
     energy1    = KINE->GetANGAs(1);    // unit: MeV
     energy2    = KINE->GetANGAr(1);    // unit: MeV
-    
+
     if(verboseLevel>1){
       G4cout << "Kine: Scattered energy:" << KINE->GetANGAs(1) << " MeV" << G4endl;
       G4cout << "Kine: Recoiled energy:" << KINE->GetANGAr(1) << " MeV" << G4endl;
@@ -1069,7 +1071,7 @@ void ActarSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
 
     G4double phi2AtEntrance = G4UniformRand() * twopi; //angle for defining the entrance point
 
-    //Entrance coordinates (x0,y0,0) 
+    //Entrance coordinates (x0,y0,0)
     G4double x0 = beamPosition.x() + radiusAtEntrance*cos(phi2AtEntrance);
     G4double y0 = beamPosition.y() + radiusAtEntrance*sin(phi2AtEntrance);
     G4double z0 = beamPosition.z();

--- a/src/ActarSimPrimaryInfo.cc
+++ b/src/ActarSimPrimaryInfo.cc
@@ -1,7 +1,7 @@
 /////////////////////////////////////////////////////////////////
-//*-- AUTHOR : Hector Alvarez-Pol 
+//*-- AUTHOR : Hector Alvarez-Pol
 //*-- Date: 04/2008
-//*-- Last Update: 22/12/2014
+//*-- Last Update: 20/06/2016
 // --------------------------------------------------------------
 // Description:
 //   The information from the primaries generated in the reaction
@@ -19,21 +19,20 @@
 #include "G4ThreeVector.hh"
 
 ClassImp(ActarSimPrimaryInfo)
-  
+
 ActarSimPrimaryInfo::ActarSimPrimaryInfo() {
   //
   // Init values
   //
   nbPrimariesInEvent = 0;
   kineticEnergy = 0;
-  theta = 0;        
-  phi =0;          
-  
-  PDGcode = 0;         
+  theta = 0;
+  phi =0;
+  PDGcode = 0;
   Px = 0;
   Py = 0;
   Pz = 0;
-  trackID = 0; 
+  trackID = 0;
   mass = 0;
   charge = 0;
   polX = 0;
@@ -41,11 +40,9 @@ ActarSimPrimaryInfo::ActarSimPrimaryInfo() {
   polZ = 0;
   Weight0 = 0;
   properTime = 0;
-
   x0 = 0.;
   y0 = 0.;
   z0 = 0.;
-
   eventID = 0;
   runID = 0;
 }
@@ -54,22 +51,22 @@ ActarSimPrimaryInfo::ActarSimPrimaryInfo(G4PrimaryParticle* prim) {
   //
   // Values from a primary
   //
-  theta = prim->GetMomentum().theta() / rad;        
-  phi = prim->GetMomentum().phi() / rad;          
-  
-  PDGcode = prim->GetPDGcode();         
+  theta = prim->GetMomentum().theta() / rad;
+  phi = prim->GetMomentum().phi() / rad;
+
+  PDGcode = prim->GetPDGcode();
   Px = prim->GetPx();
   Py = prim->GetPy();
   Pz = prim->GetPz();
-  trackID = prim->GetTrackID(); 
+  trackID = prim->GetTrackID();
   mass = prim->GetMass();
   charge = prim->GetCharge() / eplus;
   polX = prim->GetPolX();
   polY = prim->GetPolY();
   polZ = prim->GetPolZ();
   Weight0 = prim->GetWeight();
-  properTime = prim->GetProperTime() / ns;  
-  
+  properTime = prim->GetProperTime() / ns;
+
   //calculating the kinetic energy
   Double_t energysquared = (prim->GetMass()*prim->GetMass()) +
     (prim->GetPx()*prim->GetPx()+
@@ -91,32 +88,29 @@ void ActarSimPrimaryInfo::print(void){
   //
   // Prints info
   //
-  /*    G4cout << "-------------------------------------------" << G4endl;
+  G4cout << "-------------------------------------------" << G4endl;
   G4cout << "------- ActarSimPrimaryInfo::print() ---------" << G4endl;
+  G4cout << " eventID: " << eventID <<  ", runID: " << runID	 << G4endl;
   G4cout << " PDGcode: " << PDGcode
          << ", trackID: " << trackID
          << ", mass: " << mass
-         << ", charge: " << charge / eplus << " eplus"
-	 << G4endl;
+         << ", charge: " << charge / eplus << " eplus" << G4endl;
   G4cout << " Px: " << Px
          << " Py: " << Py
          << " Pz: " << Pz
-         << ", properTime: " << properTime / ns << " ns"
-         << G4endl;
+         << ", properTime: " << properTime / ns << " ns" << G4endl;
   G4cout << " polX: " << polX
          << " polY: " << polY
          << " polZ: " << polZ
-         << ", Weight0: " << Weight0
-         << G4endl;
+         << ", Weight0: " << Weight0 << G4endl;
   G4cout << " x0: " << x0 / mm << " mm"
          << " y0: " << y0 / mm << " mm"
-         << " z0: " << z0 / mm << " mm"<< G4endl;
+         << " z0: " << z0 / mm << " mm" << G4endl;
   G4cout << " nbPrimariesInEvent: " << nbPrimariesInEvent
          << ", kineticEnergy: " << kineticEnergy
          << ", theta: " << theta / rad << " rad"
-         << ", phi: " << phi / rad << " rad"<< G4endl;
+         << ", phi: " << phi / rad << " rad" << G4endl;
   G4cout << "-------------------------------------------" << G4endl;
-  */
 }
 
 
@@ -138,8 +132,8 @@ void ActarSimPrimaryInfo::SetMomentum(Double_t px, Double_t py, Double_t pz) {
   Py = py;
   Pz = pz;
   G4ThreeVector mom(Px,Py,Pz);
-  theta = mom.theta();        
-  phi = mom.phi();          
+  theta = mom.theta();
+  phi = mom.phi();
 
 }
 

--- a/src/ActarSimROOTAnalGas.cc
+++ b/src/ActarSimROOTAnalGas.cc
@@ -107,7 +107,7 @@ void ActarSimROOTAnalGas::init(){
   for (G4int i=0;i<2;i++)
     simpleTrack[i] = new ActarSimSimpleTrack();
 
-  eventTree->Branch("theData","ActarSimData",&theData,128000,99);
+  //eventTree->Branch("theData","ActarSimData",&theData,128000,99);
   tracksTree->Branch("trackData","ActarSimTrack",&theTracks,128000,99);
   //Now, simple track as a TClonesArray
   eventTree->Branch("simpleTrackData",&simpleTrackCA);
@@ -327,7 +327,7 @@ void ActarSimROOTAnalGas::EndOfEventAction(const G4Event *anEvent) {
   Double_t aTLInGas1 =0;// (TLGas1 / mm); // in [mm]
   Double_t aTLInGas2 =0;// (TLGas2 / mm); // in [mm]
 
-  if(((ActarSimROOTAnalysis*) gActarSimROOTAnalysis)->GetStoreSimpleTracksFlag()=="on"){  // added flag dypang 080301
+  if(((ActarSimROOTAnalysis*) gActarSimROOTAnalysis)->GetStoreSimpleTracksFlag()=="on"){
     //moving here the recollection of the steps info into strides
     //which was previously made in the UserSteppingAction() function
     //Now we will use the GeantHits to recover the steps from the gas


### PR DESCRIPTION
This commit modifies the way information enters into the TTree, moving from objets to
TCloneArrays in all cases. In this way duplications from even/odd events which do not
contain beam or primaries are removed (usinh TClonesArray->Clear()).
Other modifications are minor changes, as removing Branches, cleaning Print messages, ...
