### PR TITLE
Include default values for Flags in the constructor.

### DIFF
--- a/12C_batch.mac
+++ b/12C_batch.mac
@@ -68,7 +68,7 @@
 /ActarSim/det/ACTARTPCDEMOGeoIncludedFlag on
 #
 # Control of the material outside the chamber (by default Air)
-#/ActarSim/det/setMediumMat D2_STP
+#/ActarSim/det/setMediumMat Air
 #/ActarSim/det/setMediumMat Galactic
 #/ActarSim/det/setMediumMat Water
 #Electric and Magnetic fields
@@ -82,7 +82,7 @@
 #/ActarSim/det/gas/setGasMat iC4H10
 #
 # Make a gas mixture : first select number of elements (up to 10)
-# And then set all gases with their ratio 
+# And then set all gases with their ratio
 /ActarSim/det/gas/mixture/GasMixture 2
 /ActarSim/det/gas/mixture/setGasMix 1 He 0.90
 /ActarSim/det/gas/mixture/setGasMix 2 iC4H10 0.10
@@ -166,7 +166,7 @@
 #/ActarSim/gun/beamRadiusAtEntrance 1.5 mm
 #/ActarSim/gun/emittance 200.0
 /ActarSim/gun/beamDirection 0 0 1
-/ActarSim/gun/beamPosition 0 100 -19 mm 
+/ActarSim/gun/beamPosition 0 100 -19 mm
 #
 # Realistic Event-Generator on
 /ActarSim/gun/reactionFromEvGen off
@@ -202,13 +202,13 @@
 
 #/ActarSim/gun/Kine/scatteredIon 1 2 1 0.0 2.0141
 #/ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.001506179125
-#/ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.00260325 
+#/ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.00260325
 /ActarSim/gun/Kine/scatteredIon 6 12 6 0.0 12.
-#/ActarSim/gun/Kine/scatteredIon 6 13 6 0.0 13.00335483778 
+#/ActarSim/gun/Kine/scatteredIon 6 13 6 0.0 13.00335483778
 #/ActarSim/gun/Kine/scatteredIon 50 133 50 0.854 132.9238
 
 #/ActarSim/gun/Kine/recoilIon 1 1 1 0.0 1.00782503207
-#/ActarSim/gun/Kine/recoilIon 1 2 1 0.0 2.0141 
+#/ActarSim/gun/Kine/recoilIon 1 2 1 0.0 2.0141
 /ActarSim/gun/Kine/recoilIon 2 4 2 0.0 4.00260325415
 
 #/ActarSim/gun/energy 11. MeV
@@ -264,7 +264,7 @@
 # create an empty scene and add the detector geometry to it
 #/vis/drawVolume
 #/vis/scene/add/axes 0 0 0 0.1 m
-#/vis/scene/add/trajectories 
+#/vis/scene/add/trajectories
 #/vis/scene/add/hits
 #/ActarSim/event/drawTracks all
 #/ActarSim/event/printModulo 10
@@ -278,7 +278,7 @@
 /ActarSim/gun/Kine/incidentIon 6 12 6 0.0 12.
 /ActarSim/gun/Kine/targetIon 2 4 2 0.0 4.00260325415
 /ActarSim/gun/Kine/recoilIon 2 3 2 0.0 3.01602931914
-/ActarSim/gun/Kine/scatteredIon 6 13 6 0.0 13.00335483778 
+/ActarSim/gun/Kine/scatteredIon 6 13 6 0.0 13.00335483778
 #
 #
 /run/beamOn 20000

--- a/include/ActarSimBeamInfo.hh
+++ b/include/ActarSimBeamInfo.hh
@@ -32,6 +32,8 @@ private:
   Double_t yVertex;            ///< Y beam at reaction vertex position
   Double_t zVertex;            ///< Z beam at reaction vertex position
 
+  Double_t nextZVertex;        ///< Z beam for next reaction
+
   Double_t timeVertex;         ///< Time at reaction vertex postion
 
   Double_t mass;               ///< Mass of beam
@@ -68,6 +70,8 @@ public:
   inline Double_t GetYVertex() const { return yVertex; }
   inline Double_t GetZVertex() const { return zVertex; }
 
+  inline Double_t GetNextZVertex() const { return nextZVertex; }
+
   inline Double_t GetTimeVertex() const { return timeVertex; }
 
   inline Double_t GetMass() const { return mass; }
@@ -93,6 +97,8 @@ public:
   inline void SetXVertex(Double_t x) { xVertex = x; }
   inline void SetYVertex(Double_t y) { yVertex = y; }
   inline void SetZVertex(Double_t z) { zVertex = z; }
+
+  inline void SetNextZVertex(Double_t z) { nextZVertex = z; }
 
   inline void SetTimeVertex(Double_t t) { timeVertex = t; }
 

--- a/kine_batch.mac
+++ b/kine_batch.mac
@@ -77,16 +77,16 @@
 #
 # Control of the material outside the chamber (by default Air)
 #/ActarSim/det/setMediumMat Galactic
-#/ActarSim/det/setMediumMat D2_STP
+#/ActarSim/det/setMediumMat Air
 #/ActarSim/det/setMediumMat Water
 #Electric and Magnetic fields
 #/ActarSim/det/setEleField 0 5e-3 0
 #/ActarSim/det/setMagField 0 0 0 T
 #
 #
-# GAS material: isoC4H10STP, D2_STP, H2_STP
+# GAS material:
 #
-/ActarSim/det/gas/setGasMat D2_STP
+/ActarSim/det/gas/setGasMat CH4_STP
 #
 #
 /ActarSim/det/MaikoGeoIncludedFlag off
@@ -214,8 +214,8 @@
 
 #/ActarSim/gun/Kine/scatteredIon 1 2 1 0.0 2.0141
 #/ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.001506179125
-#/ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.00260325 
-/ActarSim/gun/Kine/scatteredIon 6 13 6 0.0 13.00335483778 
+#/ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.00260325
+/ActarSim/gun/Kine/scatteredIon 6 13 6 0.0 13.00335483778
 #/ActarSim/gun/Kine/scatteredIon 50 133 50 0.854 132.9238
 
 /ActarSim/gun/Kine/recoilIon 1 1 1 0.0 1.00782503207

--- a/src/ActarSimBeamInfo.cc
+++ b/src/ActarSimBeamInfo.cc
@@ -36,6 +36,7 @@ ActarSimBeamInfo::ActarSimBeamInfo() {
   xVertex = 0.;            // reaction vertex position
   yVertex = 0.;
   zVertex = 0.;
+  nextZVertex = 0.;
   timeVertex = 0.;         // time at vertex formation
   mass = 0.0;              // mass
   charge = 0.0;            // charge
@@ -67,6 +68,7 @@ void ActarSimBeamInfo::print(void){
   G4cout << " xVertex: " << xVertex / mm << " mm"
          << " yVertex: " << yVertex / mm << " mm"
 	 << " zVertex: " << zVertex / mm << " mm"<< G4endl;
+  G4cout << " Next event zVertex: " << nextZVertex / mm << " mm"<< G4endl;
   G4cout << " thetaVertex: " << thetaVertex / rad << " rad"
 	 << " phiVertex: " << phiVertex / rad << " rad"<< G4endl;
   G4cout << " Time at the reaction vertex:  " << timeVertex/ns << " ns" << G4endl;

--- a/src/ActarSimDetectorConstruction.cc
+++ b/src/ActarSimDetectorConstruction.cc
@@ -53,9 +53,11 @@ ActarSimDetectorConstruction::ActarSimDetectorConstruction()
       solidWorld(0), worldLog(0), chamberLog(0), AlplateLog(0), DiamondLog(0), SupportLog(0),
   worldPhys(0), chamberPhys(0), AlplatePhys(0), DiamondPhys(0), SupportPhys(0),
   mediumMaterial(0), defaultMaterial(0), chamberMaterial(0), windowMaterial(0),
-  emField(0), MaikoGeoIncludedFlag("off"), ACTARTPCGeoIncludedFlag("off"),
-      gasGeoIncludedFlag("on"), silGeoIncludedFlag("off"), sciGeoIncludedFlag("off"),
-      gasDet(0), silDet(0),silRingDet(0), sciDet(0), sciRingDet(0), plaDet(0) {
+  emField(0), MaikoGeoIncludedFlag("off"),
+  ACTARTPCDEMOGeoIncludedFlag("off"), ACTARTPCGeoIncludedFlag("off"),
+  gasGeoIncludedFlag("on"), silGeoIncludedFlag("off"), sciGeoIncludedFlag("off"),
+  SpecMATGeoIncludedFlag("off"), OthersGeoIncludedFlag("off"),
+  gasDet(0), silDet(0),silRingDet(0), sciDet(0), sciRingDet(0), plaDet(0) {
   //default values of half-length -> size of World (2x2x2 m3)
   worldSizeX = 1.*m;
   worldSizeY = 1.*m;
@@ -1101,7 +1103,7 @@ void ActarSimDetectorConstruction::DefineMaterials() {
   //Methane (default  0.7174*mg/cm3 STP)
   density = 0.7174*mg/cm3;
   G4Material* methane =
-    new G4Material("CH4", density, ncomponents=2) ;
+    new G4Material("CH4_STP", density, ncomponents=2) ;
   methane->AddElement(C,1);
   methane->AddElement(H,4);
 

--- a/src/ActarSimGasSD.cc
+++ b/src/ActarSimGasSD.cc
@@ -59,7 +59,10 @@ void ActarSimGasSD::Initialize(G4HCofThisEvent* HCE){
 G4bool ActarSimGasSD::ProcessHits(G4Step* aStep,G4TouchableHistory*){
 
   //G4double edep = aStep->GetTotalEnergyDeposit()/MeV;
-  G4double edep = -aStep->GetDeltaEnergy()/MeV;
+  //G4double edep = -aStep->GetDeltaEnergy()/MeV;
+  //To avoid warning messages about removing GetDeltaEnergy, the behaviour of the
+  //function is directly implemented here:
+  G4double edep = -(aStep->GetPostStepPoint()->GetKineticEnergy() - aStep->GetPreStepPoint()->GetKineticEnergy())/MeV;
 
   if(edep==0.) return false;
 

--- a/src/ActarSimPrimaryGeneratorAction.cc
+++ b/src/ActarSimPrimaryGeneratorAction.cc
@@ -261,8 +261,8 @@ void ActarSimPrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent) {
       // the reaction cross section, or even a simple exponential if a constant cross sections
       // approximation is suitable (non-resonant beam)
 
-      pBeamInfo->SetZVertex(vertex_z0);
-      pBeamInfo->SetEnergyEntrance(GetIncidentEnergy());
+      pBeamInfo->SetNextZVertex(vertex_z0);
+      pBeamInfo->SetEnergyEntrance(GetIncidentEnergy()); //no need of nextEnergyEntrance, as all entry energies are the same. If this is not true in future, an additional datamember for beamInfo will be needed
 
       if(realisticBeamFlag == "on") {
         // Emittance is defined in mm mrad

--- a/src/ActarSimROOTAnalysis.cc
+++ b/src/ActarSimROOTAnalysis.cc
@@ -656,7 +656,7 @@ void ActarSimROOTAnalysis::UserSteppingAction(const G4Step *aStep){
   // is reached. If so, store the ion position and use it for vertex generation and abort the event.
 
   if(beamInteractionFlag=="on" && pBeamInfo->GetStatus() == 1){
-    G4double zVertex = pBeamInfo->GetZVertex();
+    G4double zVertex = pBeamInfo->GetNextZVertex();
     if(aStep->GetTrack()->GetParentID()==0){
       if(aStep->GetPreStepPoint()->GetPosition().z() < zVertex &&
 	 aStep->GetPostStepPoint()->GetPosition().z() > zVertex){

--- a/src/ActarSimSilSD.cc
+++ b/src/ActarSimSilSD.cc
@@ -59,7 +59,10 @@ void ActarSimSilSD::Initialize(G4HCofThisEvent* HCE){
 /// Invoked by G4SteppingManager for each step
 G4bool ActarSimSilSD::ProcessHits(G4Step* aStep,G4TouchableHistory*){
   //G4double edep = aStep->GetTotalEnergyDeposit();
-  G4double edep = -aStep->GetDeltaEnergy()/MeV;
+  //G4double edep = -aStep->GetDeltaEnergy()/MeV;
+  //To avoid warning messages about removing GetDeltaEnergy, the behaviour of the
+  //function is directly implemented here:
+  G4double edep = -(aStep->GetPostStepPoint()->GetKineticEnergy() - aStep->GetPreStepPoint()->GetKineticEnergy())/MeV;
 
   if(edep==0.) return false;
 

--- a/vis_actarTPC.mac
+++ b/vis_actarTPC.mac
@@ -75,23 +75,23 @@
 /run/initialize
 #
 # DETECTOR CHARACTERIZATION
-# 
+#
 # PRE-DEFINED DETECTORS (if any of this predefined detectors is on, most detector commands are not used)
 /ActarSim/det/MaikoGeoIncludedFlag off           #Includes the Maiko geometry in the simulation
 /ActarSim/det/ACTARTPCDEMOGeoIncludedFlag off    #Includes the ACTARTPC Demonstrator geometry in the simulation
 /ActarSim/det/ACTARTPCGeoIncludedFlag on        #Includes the ACTARTPC geometry in the simulation
-# Control of the materials (options: Galactic, D2_STP, Water, ...)
-/ActarSim/det/setMediumMat D2_STP                #Selects Material outside the Chamber.
+# Control of the materials (options: Galactic, Water, ...)
+/ActarSim/det/setMediumMat Air                   #Selects Material outside the Chamber.
 /ActarSim/det/setChamberMat Galactic             #Selects Material in the Chamber (but not in the gas!)
 # Electric and Magnetic fields
 #/ActarSim/det/setEleField 0 5e-3 0               #Defines electric field
 #/ActarSim/det/setMagField 0 0 0 T                #Defines magnetic field
 #
 #
-# GAS CHARACTERISTICS (options are H2, D2, He, Ar, CF4, CH4, iC4H10, set both in GasBox and GasChamber) 
+# GAS CHARACTERISTICS (options are H2, D2, He, Ar, CF4, CH4, iC4H10, set both in GasBox and GasChamber)
 #
 #/ActarSim/det/gas/setGasPressure 1.01325         #Select the Gas Pressure for the Gas box
-/ActarSim/det/gas/setGasPressure 0.2 bar 
+/ActarSim/det/gas/setGasPressure 0.2 bar
 /ActarSim/det/gas/setGasTemperature 293.15       #Select the Gas Temperature for the Gas box
 #
 /ActarSim/det/gas/setGasMat iC4H10               #Select Material of the Gas for the Gas box
@@ -207,7 +207,7 @@
 #/ActarSim/gun/Kine/incidentIon 2 4 2 0.0 4.00260325
 #/ActarSim/gun/Kine/incidentIon 6 12 6 0.0 12.
 #/ActarSim/gun/Kine/incidentIon 6 13 6 0.0 13.00335483778
-/ActarSim/gun/Kine/incidentIon 9 17 9 0.0 17.002095237   #Set properties of incident ion to be generated  
+/ActarSim/gun/Kine/incidentIon 9 17 9 0.0 17.002095237   #Set properties of incident ion to be generated
 #/ActarSim/gun/Kine/incidentIon 50 132 50 0.0 131.9178
 
 /ActarSim/gun/Kine/targetIon 1 1 1 0.0 1.00782503207   #Set properties of target ion to be generated
@@ -216,13 +216,13 @@
 #/ActarSim/gun/Kine/scatteredIon 1 2 1 0.0 2.0141
 #/ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.001506179125 #alpha
 #/ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.00260325415 #4He
-#/ActarSim/gun/Kine/scatteredIon 6 12 6 0.0 12. 
-#/ActarSim/gun/Kine/scatteredIon 6 13 6 0.0 13.00335483778 
+#/ActarSim/gun/Kine/scatteredIon 6 12 6 0.0 12.
+#/ActarSim/gun/Kine/scatteredIon 6 13 6 0.0 13.00335483778
 #/ActarSim/gun/Kine/scatteredIon 50 133 50 0.854 132.9238
 /ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.001506179125   #Set properties of scattered ion to be generated
 
 #/ActarSim/gun/Kine/recoilIon 1 1 1 0.0 1.00782503207
-#/ActarSim/gun/Kine/recoilIon 1 2 1 0.0 2.0141 
+#/ActarSim/gun/Kine/recoilIon 1 2 1 0.0 2.0141
 /ActarSim/gun/Kine/recoilIon 8 14 8 0.0 14.00859625    #Set properties of recoil ion to be generated
 
 #/ActarSim/gun/time 0

--- a/vis_actarTPCDEMO.mac
+++ b/vis_actarTPCDEMO.mac
@@ -80,18 +80,18 @@
 /ActarSim/det/MaikoGeoIncludedFlag off           #Includes the Maiko geometry in the simulation
 /ActarSim/det/ACTARTPCDEMOGeoIncludedFlag on    #Includes the ACTARTPC Demonstrator geometry in the simulation
 /ActarSim/det/ACTARTPCGeoIncludedFlag off        #Includes the ACTARTPC geometry in the simulation
-# Control of the materials (options: Galactic, D2_STP, Water, ...)
-/ActarSim/det/setMediumMat D2_STP                #Selects Material outside the Chamber.
+# Control of the materials (options: Galactic, Water, ...)
+/ActarSim/det/setMediumMat Air                   #Selects Material outside the Chamber.
 /ActarSim/det/setChamberMat Galactic             #Selects Material in the Chamber (but not in the gas!)
 # Electric and Magnetic fields
 #/ActarSim/det/setEleField 0 5e-3 0               #Defines electric field
 #/ActarSim/det/setMagField 0 0 0 T                #Defines magnetic field
 #
 #
-# GAS CHARACTERISTICS (options are H2, D2, He, Ar, CF4, CH4, iC4H10, set both in GasBox and GasChamber) 
+# GAS CHARACTERISTICS (options are H2, D2, He, Ar, CF4, CH4, iC4H10, set both in GasBox and GasChamber)
 #
 #/ActarSim/det/gas/setGasPressure 1.01325         #Select the Gas Pressure for the Gas box
-/ActarSim/det/gas/setGasPressure 0.1 
+/ActarSim/det/gas/setGasPressure 0.1
 /ActarSim/det/gas/setGasTemperature 293.15       #Select the Gas Temperature for the Gas box
 #
 /ActarSim/det/gas/setGasMat iC4H10               #Select Material of the Gas for the Gas box
@@ -153,7 +153,7 @@
 #/ActarSim/gun/beamRadiusAtEntrance 18. mm        #Selects the beam radius at entrance of ACTAR. Used with the emittance to calculate the position and angle distributions of the beam when a realisticBeam option is set
 /ActarSim/gun/beamDirection 0 0 1                #Set beam momentum direction
 /ActarSim/gun/beamPosition 0 0 -69 mm           #Set beam starting position
-#/ActarSim/gun/beamPosition 0 0 -54 mm  
+#/ActarSim/gun/beamPosition 0 0 -54 mm
 /ActarSim/gun/randomTheta off                    #Select a random Theta angle for the scattered particle
 /ActarSim/gun/randomThetaVal 0 180              #Sets the limits in the Theta angle for the scattered particle. The value is randomly chosen between the limits
 /ActarSim/gun/randomPhi off                        #Select a random Phi angle for the scattered particle

--- a/vis_alpha.mac
+++ b/vis_alpha.mac
@@ -80,18 +80,18 @@
 /ActarSim/det/MaikoGeoIncludedFlag off           #Includes the Maiko geometry in the simulation
 /ActarSim/det/ACTARTPCDEMOGeoIncludedFlag on    #Includes the ACTARTPC Demonstrator geometry in the simulation
 /ActarSim/det/ACTARTPCGeoIncludedFlag off        #Includes the ACTARTPC geometry in the simulation
-# Control of the materials (options: Galactic, D2_STP, Water, ...)
-/ActarSim/det/setMediumMat D2_STP                #Selects Material outside the Chamber.
+# Control of the materials (options: Galactic, Water, ...)
+/ActarSim/det/setMediumMat Air                   #Selects Material outside the Chamber.
 /ActarSim/det/setChamberMat Galactic             #Selects Material in the Chamber (but not in the gas!)
 # Electric and Magnetic fields
 #/ActarSim/det/setEleField 0 5e-3 0               #Defines electric field
 #/ActarSim/det/setMagField 0 0 0 T                #Defines magnetic field
 #
 #
-# GAS CHARACTERISTICS (options are H2, D2, He, Ar, CF4, CH4, iC4H10, set both in GasBox and GasChamber) 
+# GAS CHARACTERISTICS (options are H2, D2, He, Ar, CF4, CH4, iC4H10, set both in GasBox and GasChamber)
 #
 #/ActarSim/det/gas/setGasPressure 1.01325         #Select the Gas Pressure for the Gas box
-/ActarSim/det/gas/setGasPressure 0.1 
+/ActarSim/det/gas/setGasPressure 0.1
 /ActarSim/det/gas/setGasTemperature 293.15       #Select the Gas Temperature for the Gas box
 #
 /ActarSim/det/gas/setGasMat iC4H10               #Select Material of the Gas for the Gas box
@@ -153,7 +153,7 @@
 #/ActarSim/gun/beamRadiusAtEntrance 18. mm        #Selects the beam radius at entrance of ACTAR. Used with the emittance to calculate the position and angle distributions of the beam when a realisticBeam option is set
 #/ActarSim/gun/beamDirection 0 0 1                #Set beam momentum direction
 #/ActarSim/gun/beamPosition 0 0 -69 mm           #Set beam starting position
-#/ActarSim/gun/beamPosition 0 0 -54 mm  
+#/ActarSim/gun/beamPosition 0 0 -54 mm
 #/ActarSim/gun/randomTheta off                    #Select a random Theta angle for the scattered particle
 #/ActarSim/gun/randomThetaVal 0 180              #Sets the limits in the Theta angle for the scattered particle. The value is randomly chosen between the limits
 #/ActarSim/gun/randomPhi off                        #Select a random Phi angle for the scattered particle

--- a/vis_kine.mac
+++ b/vis_kine.mac
@@ -69,18 +69,18 @@
 /ActarSim/det/MaikoGeoIncludedFlag off           #Includes the Maiko geometry in the simulation
 /ActarSim/det/ACTARTPCDEMOGeoIncludedFlag on    #Includes the ACTARTPC Demonstrator geometry in the simulation
 /ActarSim/det/ACTARTPCGeoIncludedFlag off        #Includes the ACTARTPC geometry in the simulation
-# Control of the materials (options: Galactic, D2_STP, Water, ...)
-/ActarSim/det/setMediumMat D2_STP                #Selects Material outside the Chamber.
+# Control of the materials (options: Galactic, Water, ...)
+/ActarSim/det/setMediumMat Air                   #Selects Material outside the Chamber.
 /ActarSim/det/setChamberMat Galactic             #Selects Material in the Chamber (but not in the gas!)
 # Electric and Magnetic fields
 #/ActarSim/det/setEleField 0 5e-3 0               #Defines electric field
 #/ActarSim/det/setMagField 0 0 0 T                #Defines magnetic field
 #
 #
-# GAS CHARACTERISTICS (options are H2, D2, He, Ar, CF4, CH4, iC4H10, set both in GasBox and GasChamber) 
+# GAS CHARACTERISTICS (options are H2, D2, He, Ar, CF4, CH4, iC4H10, set both in GasBox and GasChamber)
 #
 /ActarSim/det/gas/setGasPressure 1.01325         #Select the Gas Pressure for the Gas box
-#/ActarSim/det/gas/setGasPressure 0.1 
+#/ActarSim/det/gas/setGasPressure 0.1
 /ActarSim/det/gas/setGasTemperature 293.15       #Select the Gas Temperature for the Gas box
 #
 #/ActarSim/det/gas/setGasMat iC4H10               #Select Material of the Gas for the Gas box
@@ -142,7 +142,7 @@
 # Update is mandatory after any material,field or detector change
 #
 /ActarSim/det/update
-#/ActarSim/det/print 
+#/ActarSim/det/print
 #
 # CONTROL OF THE PRIMARY EVENTS
 #
@@ -159,7 +159,7 @@
 /ActarSim/gun/beamRadiusAtEntrance 1. mm       #Selects the beam radius at entrance of ACTAR. Used with the emittance to calculate the position and angle distributions of the beam when a realisticBeam option is set
 #
 # Realistic Event-Generator on
-/ActarSim/gun/reactionFromEvGen off 
+/ActarSim/gun/reactionFromEvGen off
 #
 # Reaction from Event-Generator
 /ActarSim/gun/reactionFromCrossSection off
@@ -185,7 +185,7 @@
 #/ActarSim/gun/Cine/incidentIon 28 78 28 0.0
 #/ActarSim/gun/Cine/targetIon 1 2 1 0.0
 #/ActarSim/gun/Cine/scatteredIon 28 79 28 0.
-#/ActarSim/gun/Cine/recoilIon 1 1 1 0.0 
+#/ActarSim/gun/Cine/recoilIon 1 1 1 0.0
 #/ActarSim/gun/Cine/reactionQ -1.5 MeV
 #/ActarSim/gun/Cine/labEnergy 624 MeV
 #/ActarSim/gun/Cine/randomTheta off
@@ -207,13 +207,13 @@
 
 #/ActarSim/gun/Kine/scatteredIon 1 2 1 0.0 2.0141
 #/ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.001506179125
-#/ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.00260325 
+#/ActarSim/gun/Kine/scatteredIon 2 4 2 0.0 4.00260325
 /ActarSim/gun/Kine/scatteredIon 6 12 6 0.0 12.
-#/ActarSim/gun/Kine/scatteredIon 6 13 6 0.0 13.00335483778 
+#/ActarSim/gun/Kine/scatteredIon 6 13 6 0.0 13.00335483778
 #/ActarSim/gun/Kine/scatteredIon 50 133 50 0.854 132.9238
 
 #/ActarSim/gun/Kine/recoilIon 1 1 1 0.0 1.00782503207
-/ActarSim/gun/Kine/recoilIon 1 2 1 0.0 2.0141 
+/ActarSim/gun/Kine/recoilIon 1 2 1 0.0 2.0141
 
 #/ActarSim/gun/time 0
 #/ActarSim/gun/polarization 0
@@ -266,7 +266,7 @@
 # create an empty scene and add the detector geometry to it
 #/vis/drawVolume
 #/vis/scene/add/axes 0 0 0 0.1 m
-/vis/scene/add/trajectories 
+/vis/scene/add/trajectories
 /vis/scene/add/hits
 #/ActarSim/event/drawTracks all
 /ActarSim/event/printModulo 10

--- a/vis_maiko.mac
+++ b/vis_maiko.mac
@@ -76,15 +76,15 @@
 /ActarSim/det/MaikoGeoIncludedFlag on           #Includes the Maiko geometry in the simulation
 /ActarSim/det/ACTARTPCDEMOGeoIncludedFlag off   #Includes the ACTARTPC Demonstrator geometry in the simulation
 /ActarSim/det/ACTARTPCGeoIncludedFlag off        #Includes the ACTARTPC geometry in the simulation
-# Control of the materials (options: Galactic, D2_STP, Water, ...)
-/ActarSim/det/setMediumMat D2                #Selects Material outside the Chamber.
+# Control of the materials (options: Galactic, Water, ...)
+/ActarSim/det/setMediumMat Air                    #Selects Material outside the Chamber.
 #/ActarSim/det/setChamberMat Galactic             #Selects Material in the Chamber (but not in the gas!)
 # Electric and Magnetic fields
 #/ActarSim/det/setEleField 0 5e-3 0               #Defines electric field
 #/ActarSim/det/setMagField 0 0 0 T                #Defines magnetic field
 #
 #
-# GAS CHARACTERISTICS (options are H2, D2, He, Ar, CF4, CH4, iC4H10, set both in GasBox and GasChamber) 
+# GAS CHARACTERISTICS (options are H2, D2, He, Ar, CF4, CH4, iC4H10, set both in GasBox and GasChamber)
 #
 /ActarSim/det/gas/setGasPressure 1.01325         #Select the Gas Pressure for the Gas box
 /ActarSim/det/gas/setGasTemperature 293.15       #Select the Gas Temperature for the Gas box
@@ -173,7 +173,7 @@
 #/ActarSim/gun/beamRadiusAtEntrance 18. mm        #Selects the beam radius at entrance of ACTAR. Used with the emittance to calculate the position and angle distributions of the beam when a realisticBeam option is set
 #/ActarSim/gun/beamDirection 0 0 1                #Set beam momentum direction
 #/ActarSim/gun/beamPosition 0 0 -69 mm           #Set beam starting position
-#/ActarSim/gun/beamPosition 0 0 -54 mm  
+#/ActarSim/gun/beamPosition 0 0 -54 mm
 #/ActarSim/gun/randomTheta off                    #Select a random Theta angle for the scattered particle
 #/ActarSim/gun/randomThetaVal 0 180              #Sets the limits in the Theta angle for the scattered particle. The value is randomly chosen between the limits
 #/ActarSim/gun/randomPhi off                        #Select a random Phi angle for the scattered particle

--- a/vis_simpleBox.mac
+++ b/vis_simpleBox.mac
@@ -68,7 +68,7 @@
 /ActarSim/det/gasGeoIncludedFlag on              #Includes the geometry of the gas volume in the simulation
 /ActarSim/det/silGeoIncludedFlag off             #Includes the geometry of the silicons in the simulation
 /ActarSim/det/sciGeoIncludedFlag off             #Includes the geometry of the scintillator in the simulation
-# Control of the materials (options: Galactic, D2_STP, Water, ...)
+# Control of the materials (options: Galactic, Water, ...)
 /ActarSim/det/setMediumMat Galactic              #Selects Material outside the Chamber.
 /ActarSim/det/setChamberMat Galactic             #Selects Material in the Chamber (but not in the gas!)
 # Electric and Magnetic fields

--- a/vis_simpleTube.mac
+++ b/vis_simpleTube.mac
@@ -69,7 +69,7 @@
 /ActarSim/det/silGeoIncludedFlag off             #Includes the geometry of the silicons in the simulation
 /ActarSim/det/sciGeoIncludedFlag off             #Includes the geometry of the scintillator in the simulation
 
-# Control of the materials (options: Galactic, D2_STP, Water, ...)
+# Control of the materials (options: Galactic, Water, ...)
 /ActarSim/det/setMediumMat Galactic              #Selects Material outside the Chamber.
 /ActarSim/det/setChamberMat Galactic             #Selects Material in the Chamber (but not in the gas!)
 # Electric and Magnetic fields


### PR DESCRIPTION
Rewrite energy deposited in gas and silicon (old GetDeltaEnergy).

To avoid warning messages about removing GetDeltaEnergy, the behaviour of the
function is directly implemented in the sensitive detectors code. Additionally the
CH4 default gas has been renamed to CH4_STP to avoid confusion.

Substitution of old gas definition in macros.

Add independent datamember in beamInfo for next event Z vertex position limit.

Solves a bug in the code. The zVertex position from the beamInfo was mixing information from the next event, as
the limit for the next event was calculated and saved in the zVertex element before the TClonesArray was filled.
Therefore, there was an event mixing, now solved.