### PR TITLE
Implement PAI physics model for testing energy loss in gases

### DIFF
--- a/include/ActarSimPhysicsList.hh
+++ b/include/ActarSimPhysicsList.hh
@@ -12,6 +12,7 @@
 
 #include "G4VModularPhysicsList.hh"
 #include "globals.hh"
+#include "G4EmConfigurator.hh"
 
 class ActarSimPhysicsListMessenger;
 class ActarSimStepLimiterBuilder;
@@ -36,6 +37,7 @@ private:
 
   ActarSimPhysicsListMessenger* pMessenger;  ///< Pointer to messenger
   ActarSimStepLimiterBuilder* steplimiter;   ///< Pointer to step limiter
+  G4EmConfigurator* fConfig;        ///< Pointer to a Em physics configurator
 
   G4VPhysicsConstructor*  emPhysicsList;     ///< Pointer to Physics list
 
@@ -53,6 +55,10 @@ public:
   void SetCutForPositron(G4double);
 
   void AddPhysicsList(const G4String&);
+  void AddPAIModel(const G4String& modname);
+  void NewPAIModel(const G4ParticleDefinition* part,
+                                          const G4String& modname,
+                                          const G4String& procname);
   void SetVerbose(G4int val);
 };
 #endif

--- a/readerPads.C
+++ b/readerPads.C
@@ -162,7 +162,7 @@ void reader(const char* inputSimFile, const char* inputDigiFile, Int_t run, Int_
 
   if(!shown){
     cout << "Reading input simulation file " << inputSimFile << endl;
-    cout << " input digitization file " << inputSimFile << endl;
+    cout << " input digitization file " << inputDigiFile << endl;
     cout << " for run " << run << " and event " << event << " (- 1 means all events)." << endl;}
   inputSimFile_g = inputSimFile;
   inputDigiFile_g = inputDigiFile;

--- a/src/ActarSimGasDetectorConstruction.cc
+++ b/src/ActarSimGasDetectorConstruction.cc
@@ -30,6 +30,8 @@
 #include "G4RunManager.hh"
 #include "G4Transform3D.hh"
 
+#include "G4Region.hh"
+
 #include "globals.hh"
 
 #include "G4PhysicalConstants.hh"
@@ -234,6 +236,10 @@ G4VPhysicalVolume* ActarSimGasDetectorConstruction::ConstructGas(G4LogicalVolume
   //------------------------------------------------
   gasLog->SetSensitiveDetector( detConstruction->GetGasSD() );
 
+  //Region (test for PAI)
+  G4Region* activeGas = new G4Region("ActiveGas");
+  activeGas->AddRootLogicalVolume(gasLog);
+
   //------------------------------------------------------------------
   // Visualization attributes
   //------------------------------------------------------------------
@@ -329,7 +335,7 @@ void ActarSimGasDetectorConstruction::SetGasMaterial (G4String mat) {
   //density	=(0.16642*293.15*kelvin*pressure)/(1.01325*bar*temperature)*mg/cm3;
   density	= (39.9481/Vm)*mg/cm3;
   G4Material* Ar =
-    new G4Material("Ar", z=2, a=39.9481*g/mole, density, kStateGas, temperature, pressure);
+    new G4Material("Ar", z=18, a=39.9481*g/mole, density, kStateGas, temperature, pressure);
 
   //CF4 (default  3.6586*mg/cm3 STP)
   //density	=(3.6586*293.15*kelvin*pressure)/(1.01325*bar*temperature)*mg/cm3;


### PR DESCRIPTION
The PAI has been recommended (Geant4 physics list, RD51, ...) for describing the energy loss in gases
at low energies. The model has been included in the "activeGas" region, defined in the logical gas
volume. The code copies from testEm8 in some parts. Additionally the commit includes correction in the
Z number assigned to the Argon and on the input arguments in readerPads.C.